### PR TITLE
Update pyproject.toml to fix CI issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ version = "0.0.1"
 
 [project.optional-dependencies]
 triton = [
-  "triton @ git+https://github.com/triton-lang/triton.git",
-  "triton_kernels @ git+https://github.com/triton-lang/triton.git#subdirectory=python/triton_kernels",
+  "triton>=3.4.0",
   "safetensors>=0.5.3",
   "torch>=2.7.0",
 ]


### PR DESCRIPTION
a simple fix, removing the triton kernels and ussing the latest version of triton instead of using git+ which will cause publishing to fail because using it gets rejected, I also removed triton kernels because I belive it isnt required