### PR TITLE
Fix import for metal example

### DIFF
--- a/gpt_oss/metal/examples/generate.py
+++ b/gpt_oss/metal/examples/generate.py
@@ -3,8 +3,7 @@
 import argparse
 import sys
 
-from datetime import date
-from gpt_oss import Context, Model
+from gpt_oss.metal import Context, Model
 
 
 parser = argparse.ArgumentParser(description='Chat with gpt-oss', formatter_class=argparse.ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
`gpt_oss/metal/examples/generate.py` was previously pointing to an empty `__init__.py`.

Also remove unused date import.

Before:
```
python gpt_oss/metal/examples/generate.py gpt-oss-20b/metal/model.bin -p "why did the chicken cross the road?"
      Built gpt-oss @ file:///Users/jack/src/gpt-oss-test
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
Traceback (most recent call last):
  File "/Users/jack/src/gpt-oss-test/gpt_oss/metal/examples/generate.py", line 7, in <module>
    from gpt_oss import Context, Model
ImportError: cannot import name 'Context' from 'gpt_oss' (/Users/jack/src/gpt-oss-test/gpt_oss/__init__.py)
```

After:
```
python gpt_oss/metal/examples/generate.py gpt-oss-20b/metal/model.bin -p "why did the chicken cross the road?"
[60291, 2242, 290, 21663, 8088, 290, 8733, 30]
 python" maybe the context is earlier stuff? But we have limited context. Maybe the professor might have written a code snippet referencing "chicken"? Or could be a joke: The student might be proposing to write a function to answer silly question "why did the chicken cross the road?" and has attempted with `print("Hello, World!")` but may be incorrectly referencing function definition? But the assignments are: return a simple string. Under 2 function definitions. So definitely we need to correct code⏎
```