### PR TITLE
Fix TOML parsing errors in pyproject.toml for scikit-build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This repository provides a collection of reference implementations:
 
 ### Requirements
 
+- python 3.12
 - On macOS: Install the Xcode CLI tools --> `xcode-select --install`
 - On Linux: These reference implementations require CUDA
 - On Windows: These reference implementations have not been tested on Windows. Try using solutions like Ollama if you are trying to run the model locally.
@@ -151,7 +152,7 @@ If you want to modify the code or try the metal implementation set the project u
 
 ```shell
 git clone https://github.com/openai/gpt-oss.git
-pip install -e .[metal]
+pip install -e ".[metal]"
 ```
 
 ## Download the model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,10 @@ packages = ["gpt_oss"]
 
 [tool.scikit-build]
 cmake.source-dir = "." # pick up the root CMakeLists.txt
-wheel.packages = ["gpt_oss"] # copy the whole Python package tree
 cmake.args = [
   "-DGPTOSS_BUILD_PYTHON=ON",
   "-DCMAKE_BUILD_TYPE=Release",
   "-DBUILD_SHARED_LIBS=OFF",
 ]
 [tool.scikit-build.wheel]
-plat-name = "manylinux_2_17_x86_64"
+packages = ["gpt_oss"] # copy the whole Python package tree


### PR DESCRIPTION
## Issue
The project installation was failing with TOML parsing errors due to duplicate wheel configuration in pyproject.toml. 

The error:
```zsh
File "/Users/enochkan/Projects/gpt-oss/venv/lib/python3.12/site-packages/pip/_internal/pyproject.py", line 70, in load_pyproject_toml
    pp_toml = tomllib.loads(f.read())
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tomllib/_parser.py", line 113, in loads
    pos, header = create_dict_rule(src, pos, out)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tomllib/_parser.py", line 290, in create_dict_rule
    raise suffixed_err(src, pos, f"Cannot declare {key} twice")
tomllib.TOMLDecodeError: Cannot declare ('tool', 'scikit-build', 'wheel') twice (at line 51, column 25)
```

The error `"Cannot declare ('tool', 'scikit-build', 'wheel') twice"` occurred because:

1. `wheel.packages = ["gpt_oss"]` was declared in the main `[tool.scikit-build]` section
2. A separate `[tool.scikit-build.wheel]` section also existed
3. The `plat-name` option was invalid for scikit-build-core

## Fix
- Moved `packages = ["gpt_oss"]` from the main scikit-build section to the proper `[tool.scikit-build.wheel]` subsection
- Removed the invalid `plat-name = "manylinux_2_17_x86_64"` option
- Updated README.md to reflect the correct Python version requirement (3.12)
- Updated README.md to include a `pip install -e .[metal]` command that overcomes shell globbing. 

This resolves the TOML parsing errors and allows the project to install successfully with scikit-build-core.