### PR TITLE
Add some links to awesome-gpt-oss.md

### DIFF
--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -10,6 +10,7 @@ This is a list of guides and resources to help you get started with the gpt-oss 
   - [Cloud](#cloud)
 - [Examples / Tutorials](#examples--tutorials)
 - [Tools](#tools)
+- [Training](#Training)
 
 ## Inference
 
@@ -70,6 +71,11 @@ This is a list of guides and resources to help you get started with the gpt-oss 
 
 - [Example `python` tool for gpt-oss](./gpt_oss/tools/python_docker/)
 - [Example `browser` tool for gpt-oss](./gpt_oss/tools/simple_browser/)
+
+## Training
+
+- [Hugging Face TRL examples](https://github.com/huggingface/gpt-oss-recipes)
+- [LlamaFactory examples](https://github.com/hiyouga/LLaMA-Factory/pull/8826)
 
 ## Contributing
 

--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -10,7 +10,7 @@ This is a list of guides and resources to help you get started with the gpt-oss 
   - [Cloud](#cloud)
 - [Examples / Tutorials](#examples--tutorials)
 - [Tools](#tools)
-- [Training](#Training)
+- [Training](#training)
 
 ## Inference
 

--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -75,7 +75,8 @@ This is a list of guides and resources to help you get started with the gpt-oss 
 ## Training
 
 - [Hugging Face TRL examples](https://github.com/huggingface/gpt-oss-recipes)
-- [LlamaFactory examples](https://github.com/hiyouga/LLaMA-Factory/pull/8826)
+- [LlamaFactory examples](https://llamafactory.readthedocs.io/en/latest/advanced/best_practice/gpt-oss.html)
+- [Unsloth examples](https://docs.unsloth.ai/basics/gpt-oss-how-to-run-and-fine-tune)
 
 ## Contributing
 


### PR DESCRIPTION
3 opensource frameworks support GPT-OSS training:

- Hugging Face TRL: https://github.com/huggingface/gpt-oss-recipes
- LlamaFactory: https://llamafactory.readthedocs.io/en/latest/advanced/best_practice/gpt-oss.html
- Unsloth: https://docs.unsloth.ai/basics/gpt-oss-how-to-run-and-fine-tune

Hope this documentation can help more people who want to work with GPT-OSS.