### PR TITLE
fix: fix f-string unmatched '(' bug in streamlit_chat.py

### DIFF
--- a/examples/streamlit/streamlit_chat.py
+++ b/examples/streamlit/streamlit_chat.py
@@ -173,7 +173,7 @@ def run(container):
             item = data.get("item", {})
             if item.get("type") == "function_call":
                 with container.chat_message("function_call", avatar="🔨"):
-                    st.markdown(f"Called `{item.get("name")}`")
+                    st.markdown(f"Called `{item.get('name')}`")
                     st.caption("Arguments")
                     st.code(item.get("arguments", ""), language="json")
             if item.get("type") == "web_search_call":
@@ -223,7 +223,7 @@ for msg in st.session_state.messages:
                     st.markdown(item["text"])
     elif msg.get("type") == "function_call":
         with st.chat_message("function_call", avatar="🔨"):
-            st.markdown(f"Called `{msg.get("name")}`")
+            st.markdown(f"Called `{msg.get('name')}`")
             st.caption("Arguments")
             st.code(msg.get("arguments", ""), language="json")
     elif msg.get("type") == "function_call_output":


### PR DESCRIPTION
## Bug Description

There is a SyntaxError in `examples/streamlit/streamlit_chat.py` when running the script, caused by unmatched parentheses in an f-string.

## File
`examples/streamlit/streamlit_chat.py`

## Error message
```
  File "examples/streamlit/streamlit_chat.py", line 176
    st.markdown(f"Called `{item.get("name")}`")
                                     ^
SyntaxError: f-string: unmatched '('
```

## How to reproduce

Run the script with Python, for example, in a Jupyter notebook or with Streamlit, and you will encounter this error.

## Solution

Change the inner double quotes to single quotes inside the f-string, like this:
```python
st.markdown(f"Called `{item.get('name')}`")
```
This fixes the unmatched parentheses SyntaxError and allows the script to run properly.