### PR TITLE
fix ImportError in build-system-prompt.py

### DIFF
--- a/gpt-oss-mcp-server/build-system-prompt.py
+++ b/gpt-oss-mcp-server/build-system-prompt.py
@@ -1,7 +1,7 @@
 import datetime
 import asyncio
 
-from gpt_oss.tokenizer import tokenizer
+from gpt_oss.tokenizer import get_tokenizer
 
 from openai_harmony import (
     Conversation,
@@ -66,6 +66,7 @@ def post_process_tools_description(
 
     return list_tools_result
 
+tokenizer = get_tokenizer()
 
 tools_urls = [
     "http://localhost:8001/sse",  # browser


### PR DESCRIPTION
### Fix `ImportError` in `gpt-oss-mcp-server/build-system-prompt.py`

**Problem**
`build-system-prompt.py` tried to `from gpt_oss.tokenizer import tokenizer`, but only `get_tokenizer()` exists, causing:

```
ImportError: cannot import name 'tokenizer'
```

**Fix**

```python
-from gpt_oss.tokenizer import tokenizer
+from gpt_oss.tokenizer import get_tokenizer
+tokenizer = get_tokenizer()
```
