### PR TITLE
fix: support editable install for PEP 660-compliant tool (e.g. `uv`)

### DIFF
--- a/_build/gpt_oss_build_backend/backend.py
+++ b/_build/gpt_oss_build_backend/backend.py
@@ -85,16 +85,20 @@ def prepare_metadata_for_build_wheel(
 
 
 # Optional hooks
-
 def build_editable(
-    editable_directory: str, config_settings: Mapping[str, Any] | None = None
+    editable_directory: str,
+    config_settings: Mapping[str, Any] | None = None,
+    metadata_directory: str | None = None,
 ) -> str:
     be = _backend()
     fn = getattr(be, "build_editable", None)
     if fn is None:
-        # setuptools implements build_editable; if not available, raise the standard error
         raise RuntimeError("Editable installs not supported by the selected backend")
-    return fn(editable_directory, config_settings)
+    try:
+        return fn(editable_directory, config_settings, metadata_directory)
+    except TypeError:
+        # fallback for backends that accept only 2 arguments
+        return fn(editable_directory, config_settings)
 
 
 def get_requires_for_build_wheel(


### PR DESCRIPTION
This PR updates the `build_editable()` hook in `backend.py` to support the optional third argument `metadata_directory`, as defined by [PEP 660](https://peps.python.org/pep-0660/).

This ensures compatibility with modern build tools like `uv`, which pass three arguments to this function.

The updated implementation falls back to 2-argument calls if the selected backend does not support 3 arguments, ensuring full backward compatibility.
<img width="844" height="269" alt="image" src="https://github.com/user-attachments/assets/e6dad774-edb1-45fc-b631-67107231427f" />

<img width="786" height="231" alt="image" src="https://github.com/user-attachments/assets/486b3557-3a1b-4f33-a7b0-3f94d0814517" />
