### PR TITLE
docs: Triton implementation need install triton_kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ git clone https://github.com/triton-lang/triton
 cd triton/
 pip install -r python/requirements.txt
 pip install -e . --verbose --no-build-isolation
+pip install -e python/triton_kernels
 
 # Install the gpt-oss triton implementation
 pip install -e ".[triton]"


### PR DESCRIPTION
The Triton implementation includes the statement:

```Python
import triton_kernels
```

But triton_kernels is not bundled or installed by the top-level [setup.py](https://github.com/triton-lang/triton/blob/450dabd3ba374103167c3bbb68e590b21b3c2c90/setup.py). Consequently, users must manually run:

```bash
pip install -e python/triton_kernels
```
