### PR TITLE
Refactor: Improve readability of file magic check in model.c

### DIFF
--- a/gpt_oss/metal/source/model.c
+++ b/gpt_oss/metal/source/model.c
@@ -112,19 +112,7 @@ enum gptoss_status GPTOSS_ABI gptoss_model_create_from_file(
     }
     file_offset += sizeof(file_header);
 
-    if (file_header.magic[0] != 'G' ||
-        file_header.magic[1] != 'P' ||
-        file_header.magic[2] != 'T' ||
-        file_header.magic[3] != '-' ||
-        file_header.magic[4] != 'O' ||
-        file_header.magic[5] != 'S' ||
-        file_header.magic[6] != 'S' ||
-        file_header.magic[7] != ' ' ||
-        file_header.magic[8] != 'v' ||
-        file_header.magic[9] != '1' ||
-        file_header.magic[10] != '.' ||
-        file_header.magic[11] != '0' ||
-        file_header.zero != 0)
+    if (memcmp(file_header.magic, "GPT-OSS v1.0", 12) != 0 || file_header.zero != 0)
     {
         GPTOSS_LOG_ERROR("invalid magic in file %s", path);
         status = gptoss_status_invalid_argument;


### PR DESCRIPTION
Hi there!

I noticed a small area in `gpt_oss/metal/source/model.c` that could be made a bit more readable and maintainable.

This PR refactors the file magic number check in the `gptoss_model_create_from_file` function to use `memcmp` instead of a series of individual character comparisons.

### What's the benefit?

* **Better Readability:** The new code more clearly states the intent, which is to compare the entire magic string. It's a bit easier to understand at a glance.
* **Easier to Maintain:** If the magic string ever needs to be updated, it's now a single-line change, which is less prone to errors.
* **Performance:** While likely a micro-optimization, `memcmp` is typically faster as it's heavily optimized in the standard library.

This is a small code quality improvement, but I hope it helps keep the codebase clean and easy to work with.

Let me know if you have any feedback!