### PR TITLE
Fix: Correct logical error in Transformers example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ outputs = pipe(
     messages,
     max_new_tokens=256,
 )
-print(outputs[0]["generated_text"][-1])
+print(outputs[0]["generated_text"][-1]['content'])
 ```
 
 [Learn more about how to use gpt-oss with Transformers.](https://cookbook.openai.com/articles/gpt-oss/run-transformers)


### PR DESCRIPTION
This PR corrects a logical error in the Transformers code example within the `README.md` file.

## Change Made
I changed `print(outputs[0]["generated_text"][-1])` to `print(outputs[0]["generated_text"][-1]['content'])` to properly extract and display the response's content.

## Change Description
The current Transformers example would print the entire final message object from the pipeline as a dictionary instead of just the response content that users expect to see. This makes the example confusing and not user-friendly for devs following the example.

This change now correctly extracts only the string value associated with the `'content'` key, ensuring the output is clean and human-readable, which was the clear intention of this example.