### PR TITLE
Fix README documentation for running it on metal

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ huggingface-cli download openai/gpt-oss-20b --include "metal/*" --local-dir gpt-
 To test it you can run:
 
 ```shell
-python gpt_oss/metal/examples/generate.py gpt-oss-20b/metal/model.bin -p "why did the chicken cross the road?"
+python gpt_oss/metal/examples/generate.py gpt-oss-20b/metal/metal/model.bin -p "why did the chicken cross the road?"
 ```
 
 ## Harmony format & tools


### PR DESCRIPTION
`huggingface-cli download openai/gpt-oss-20b --include "metal/*" --local-dir gpt-oss-20b/metal/` installs the model at `gpt-oss-20b/metal/metal/model.bin` not `gpt-oss-20b/metal/model.bin`