### PR TITLE
fix(build): normalize GPTOSS_BUILD_METAL to handle 'True' and other common values

### DIFF
--- a/_build/gpt_oss_build_backend/backend.py
+++ b/_build/gpt_oss_build_backend/backend.py
@@ -33,7 +33,11 @@ from importlib import import_module
 from typing import Any, Mapping, Sequence
 
 
-TRUE_VALUES = {"1", "true", "TRUE", "on", "ON", "yes", "YES"}
+TRUE_VALUES = {
+    "1", "true", "True", "TRUE",
+    "on", "ON",
+    "yes", "YES",
+}
 
 
 def _use_metal_backend() -> bool:


### PR DESCRIPTION
**What’s fixed :**

When trying to enable the Metal backend with:
```
export GPTOSS_BUILD_METAL=True
pip install -e ".[metal]"
```

the build silently falls back to the pure-Python version, even though the environment variable is clearly set.

This happens because the _use_metal_backend() function checks against a set of valid “truthy” strings, but "True" (capital T) wasn’t included — only "true", "1", "on", etc. were allowed.

**Solution** : 

I added "**True**" to the TRUE_VALUES set in backend.py, so users can now enable the Metal backend using either "True" or "true", which is more intuitive and Pythonic.

**Why it matters** : 

This small fix improves the developer experience on macOS by:

Making the env var more forgiving and natural

**### Avoiding silent fallbacks to CPU builds**

Preventing confusion when the Metal backend doesn’t compile, even when the flag seems correctly set

Let me know if you’d prefer this handled differently (e.g. normalize input with .lower() instead).

 Thanks!