### PR TITLE
Fix: max_tokens handling in generate.py

### DIFF
--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -28,7 +28,8 @@ def main(args):
 
     tokenizer = get_tokenizer()
     tokens = tokenizer.encode(args.prompt)
-    for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=args.limit, return_logprobs=True):
+    max_tokens = None if args.limit == 0 else args.limit
+    for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=max_tokens, return_logprobs=True):
         tokens.append(token)
         decoded_token = tokenizer.decode([token])
         print(


### PR DESCRIPTION
Problem:
Passing args.limit=0 as max_tokens=0 to TokenGenerator may not reliably disable the token limit, leading to inconsistent behavior.

Solution:
Update generate.py to set max_tokens=None when args.limit=0, explicitly signaling no limit.

Impact:
Prevents misinterpretation of limit=0, ensuring expected behavior and improving script robustness.