### PR TITLE
Fix typos 'lenght' -> 'length' in browser tool files

### DIFF
--- a/gpt_oss/tools/simple_browser/page_contents.py
+++ b/gpt_oss/tools/simple_browser/page_contents.py
@@ -87,13 +87,13 @@ def mark_lines(text: str) -> str:
 
 
 @functools.cache
-def _tiktoken_vocabulary_lenghts(enc_name: str) -> list[int]:
+def _tiktoken_vocabulary_lengths(enc_name: str) -> list[int]:
     encoding = tiktoken.get_encoding(enc_name)
     return [len(encoding.decode([i])) for i in range(encoding.n_vocab)]
 
 
 def warmup_caches(enc_names: list[str]) -> None:
-    for _ in map(_tiktoken_vocabulary_lenghts, enc_names):
+    for _ in map(_tiktoken_vocabulary_lengths, enc_names):
         pass
 
 

--- a/gpt_oss/tools/simple_browser/simple_browser_tool.py
+++ b/gpt_oss/tools/simple_browser/simple_browser_tool.py
@@ -102,8 +102,8 @@ def max_chars_per_token(enc_name: str) -> int:
 def get_tokens(text: str, enc_name: str) -> Tokens:
     encoding = tiktoken.get_encoding(enc_name)
     tokens = encoding.encode(text, disallowed_special=())
-    _vocabulary_lenghts = _tiktoken_vocabulary_lengths(enc_name)
-    tok2idx = [0] + list(itertools.accumulate(_vocabulary_lenghts[i] for i in tokens))[
+    _vocabulary_lengths = _tiktoken_vocabulary_lengths(enc_name)
+    tok2idx = [0] + list(itertools.accumulate(_vocabulary_lengths[i] for i in tokens))[
         :-1
     ]
     result = Tokens(tokens=tokens, tok2idx=tok2idx)


### PR DESCRIPTION
Simply fixes some typos in both method and variable names because of my OCD