### PR TITLE
chat / api_server: do not include developer messages to reduce mismatch

### DIFF
--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -120,9 +120,11 @@ def main(args):
             ])
         )
         messages.append(Message.from_role_and_content(Role.DEVELOPER, developer_message_content))
-    else:
+    elif args.developer_message:
         developer_message_content = DeveloperContent.new().with_instructions(args.developer_message)
         messages.append(Message.from_role_and_content(Role.DEVELOPER, developer_message_content))
+    else:
+        developer_message_content = None
 
     if args.raw:
         conversation = Conversation.from_messages(messages)
@@ -142,9 +144,9 @@ def main(args):
         print(termcolor.colored("Browser Tool:", "cyan"), "Enabled" if args.browser else "Disabled", flush=True)
         print(termcolor.colored("Python Tool:", "cyan"), "Enabled" if args.python else "Disabled", flush=True)
         print(termcolor.colored("Apply Patch Function:", "cyan"), "Enabled" if args.apply_patch else "Disabled", flush=True)
-        # Developer message
-        print(termcolor.colored("Developer Message:", "yellow"), flush=True)
-        print(developer_message_content.instructions, flush=True)
+        if developer_message_content:
+            print(termcolor.colored("Developer Message:", "yellow"), flush=True)
+            print(developer_message_content.instructions, flush=True)
 
     # Print the system message and the user message start
     MESSAGE_PADDING = 12

--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -793,16 +793,16 @@ def create_api_server(
         system_message = Message.from_role_and_content(
             Role.SYSTEM, system_message_content
         )
+        messages = [system_message]
 
-        developer_message_content = DeveloperContent.new().with_instructions(
-            body.instructions
-        )
+        if body.instructions or body.tools:
+            developer_message_content = DeveloperContent.new().with_instructions(
+                body.instructions
+            )
 
-        tools = []
-        if body.tools:
+            tools = []
             for tool in body.tools:
                 if tool.type == "function":
-                    has_functions = True
                     tools.append(
                         ToolDescription.new(
                             tool.name,
@@ -810,17 +810,17 @@ def create_api_server(
                             tool.parameters,
                         )
                     )
-        
-        if len(tools) > 0:
-            developer_message_content = developer_message_content.with_function_tools(
-                tools
+
+            if tools:
+                developer_message_content = developer_message_content.with_function_tools(
+                    tools
+                )
+
+            developer_message = Message.from_role_and_content(
+                Role.DEVELOPER, developer_message_content
             )
 
-        developer_message = Message.from_role_and_content(
-            Role.DEVELOPER, developer_message_content
-        )
-
-        messages = [system_message, developer_message]
+            messages.append(developer_message)
 
         if isinstance(body.input, str):
             user_message = Message.from_role_and_content(Role.USER, body.input)


### PR DESCRIPTION
Matching system prompts is important to get consistent results across implementations.