### PR TITLE
refactor: rename search_tool for clarity

### DIFF
--- a/examples/agents-sdk-python/example.py
+++ b/examples/agents-sdk-python/example.py
@@ -59,14 +59,14 @@ async def main():
 
     # Define weather tool
     @function_tool
-    async def search_tool(location: str) -> str:
+    async def get_weather(location: str) -> str:
         return f"The weather in {location} is sunny."
 
     # Create agent
     agent = Agent(
         name="My Agent",
         instructions="You are a helpful assistant.",
-        tools=[search_tool],
+        tools=[get_weather],
         model="gpt-oss:20b-test",
         mcp_servers=[mcp_server],
     )


### PR DESCRIPTION
The function originally named `search_tool` has a specific purpose of fetching weather information, but the name was too generic.

Renaming it to `get_weather` increases readability and maintainability for future developers.