### PR TITLE
chore: remove unused WeatherParams class and import

### DIFF
--- a/examples/agents-sdk-python/example.py
+++ b/examples/agents-sdk-python/example.py
@@ -13,11 +13,6 @@ from agents import (
     function_tool,
 )
 from agents.mcp import MCPServerStdio
-from pydantic import BaseModel
-
-
-class WeatherParams(BaseModel):
-    location: str
 
 
 async def prompt_user(question: str) -> str:


### PR DESCRIPTION
Removes the unused `WeatherParams` class and its corresponding `BaseModel` import from `pydantic`.

This code was not referenced anywhere in the script. Removing it reduces clutter.