### PR TITLE
Feat: add command-line arguments for backend parameters

### DIFF
--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -19,10 +19,10 @@ def main(args):
             from gpt_oss.torch.utils import init_distributed
             from gpt_oss.triton.model import TokenGenerator as TritonGenerator
             device = init_distributed()
-            generator = TritonGenerator(args.checkpoint, context=4096, device=device)
+            generator = TritonGenerator(args.checkpoint, context=args.context_length, device=device)
         case "vllm":
             from gpt_oss.vllm.token_generator import TokenGenerator as VLLMGenerator
-            generator = VLLMGenerator(args.checkpoint, tensor_parallel_size=2)
+            generator = VLLMGenerator(args.checkpoint, tensor_parallel_size=args.tensor_parallel_size)
         case _:
             raise ValueError(f"Invalid backend: {args.backend}")
 
@@ -31,9 +31,9 @@ def main(args):
     max_tokens = None if args.limit == 0 else args.limit
     for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=max_tokens, return_logprobs=True):
         tokens.append(token)
-        decoded_token = tokenizer.decode([token])
+        token_text = tokenizer.decode([token])
         print(
-            f"Generated token: {repr(decoded_token)}, logprob: {logprob}"
+            f"Generated token: {repr(token_text)}, logprob: {logprob}"
         )
 
 
@@ -77,6 +77,18 @@ if __name__ == "__main__":
         default="torch",
         choices=["triton", "torch", "vllm"],
         help="Inference backend",
+    )
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=2,
+        help="Tensor parallel size for vLLM backend",
+    )
+    parser.add_argument(
+        "--context-length",
+        type=int,
+        default=4096,
+        help="Context length for Triton backend",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
  This pull request enhances the flexibility of the gpt_oss/generate.py script
  by replacing hardcoded backend parameters with configurable command-line
  arguments.

  Previously, the triton and vllm backends had fixed values for context and
  tensor_parallel_size, respectively. This made it difficult to adapt the
  script to different models or hardware configurations without modifying the
  source code.

  This PR introduces two new arguments:
   - --context-length: Allows customization of the context length for the triton
     backend (defaults to 4096).
   - --tensor-parallel-size: Allows customization of the tensor parallel size for
     the vllm backend (defaults to 2).

  Additionally, the variable decoded_token has been renamed to token_text for
  improved clarity.

  These changes make the generation script more versatile and user-friendly,
  allowing for easier experimentation with different backend settings.