### PR TITLE
Fix packaging so that it includes evals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ requires = ["setuptools>=68"]
 build-backend = "gpt_oss_build_backend.backend"
 backend-path = ["_build"]
 
-[tool.setuptools]
-packages = ["gpt_oss"]
+[tool.setuptools.packages.find]
+include = ["gpt_oss*"]
 
 [tool.scikit-build]
 cmake.source-dir = "." # pick up the root CMakeLists.txt


### PR DESCRIPTION
Main (After `pip install .`):

```
python -m gpt_oss.evals --model 120b-low --eval gpqa --n-threads 128
/home/lwilkinson/tmp2/.venv/bin/python: No module named gpt_oss.evals
```

PR (After `pip install .`):

```
python -m gpt_oss.evals --help
usage: __main__.py [-h] [--model MODEL] [--reasoning-effort REASONING_EFFORT] [--sampler {responses,chat_completions}] [--base-url BASE_URL] [--eval EVAL] [--temperature TEMPERATURE] [--n-threads N_THREADS]
                   [--debug] [--examples EXAMPLES]
...
```