### PR TITLE
fix(evals): include content-part text in ResponsesSampler transcripts; chore: ignore .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg*
 node_modules/
 *.log
+.venv/

--- a/gpt_oss/evals/responses_sampler.py
+++ b/gpt_oss/evals/responses_sampler.py
@@ -66,8 +66,14 @@ class ResponsesSampler(SamplerBase):
                         message_list.append(self._pack_message(getattr(output, "role", "assistant"), output.text))
                     elif hasattr(output, "content"):
                         for c in output.content:
-                            # c.text handled below
-                            pass
+                            # Append any text content parts so message_list reflects the response
+                            if hasattr(c, "text") and getattr(c, "text"):
+                                message_list.append(
+                                    self._pack_message(
+                                        getattr(output, "role", "assistant"),
+                                        c.text,
+                                    )
+                                )
 
                 return SamplerResponse(
                     response_text=response.output_text,


### PR DESCRIPTION
What?
- Update `gpt_oss/evals/responses_sampler.py` to append `c.text` from `output.content` so `actual_queried_message_list` includes all assistant text, not just output.text.
- Add `.venv/` to .gitignore.

Why?
- The Responses API can return assistant output as content items. Previously, these were skipped (stale comment claimed they’d be handled later), leading to incomplete eval transcripts and potentially misleading metrics.
- `.venv/` should not be committed.