### PR TITLE
Fix: Prevent TypeError in PythonTool by passing channel

### DIFF
--- a/gpt_oss/tools/python_docker/docker_tool.py
+++ b/gpt_oss/tools/python_docker/docker_tool.py
@@ -92,9 +92,10 @@ When you send a message containing python code to python, it will be executed in
     def _make_response(
         self,
         output: str,
+        channel: str | None = None
     ) -> Message:
         content = TextContent(text=output)
-        return self.make_response(content=content)
+        return self.make_response(content=content, channel=channel)
 
     def make_response(
         self,


### PR DESCRIPTION
This PR fixes a critical bug in `docker_tool.py` that causes a `TypeError` when `PythonTool` processes a message.

## Change Description
The `PythonTool._process` method attempts to call `self._make_response(output, channel=channel)`. But, the `_make_response` method was not defined to accept a `channel` argument. This mismatch caused the program to crash and produce a TypeError.

Here is the call that incorrectly passes `channel`: 

`yield self._make_response(output, channel=channel)`

## Change Made
Therefore I added the `channel` parameter to the `_make_response` method and passed it through to the existing `make_response` method.