### PR TITLE
Fix: Correct token names and correct parser in create-local-model.py

### DIFF
--- a/gpt_oss/metal/scripts/create-local-model.py
+++ b/gpt_oss/metal/scripts/create-local-model.py
@@ -14,7 +14,7 @@ from safetensors import safe_open
 from tqdm import tqdm
 from openai_harmony import load_harmony_encoding, HarmonyEncodingName
 
-parser = argparse.ArgumentParser(prog='check-mxfp4-weights.py', description='Validated MXFP4 weights')
+parser = argparse.ArgumentParser(prog='create-local-model.py',description='Creates a local model file from a checkpoint')
 parser.add_argument('-s', '--src', metavar='DIR', type=str, required=True, help='Path to the input checkpoint directory')
 parser.add_argument('-d', '--dst', metavar='FILE', type=str, required=True, help='Path to the output model file')
 
@@ -30,7 +30,7 @@ o200k_gptoss = tiktoken.Encoding(
         "<|reversed199998|>": 199998,  # unused
         "<|endoftext|>": 199999,
         "<|untrusted|>": 200000,
-        "<|endofuntrusted|>": 200001,
+        "<|end_untrusted|>": 200001,
         "<|return|>": 200002,
         "<|constrain|>": 200003,
         "<|reversed200004|>": 200004,  # unused


### PR DESCRIPTION
This PR addresses two distinct bugs in the `/metal/scripts/create-local-model.py` script to prevent a runtime error and fix the prog and description outputted.

## Change Description
There is an inconsistency in the naming of the `<|endofuntrusted|>` special token.

In the `o200k_gptoss` definition, it is named `"<|endofuntrusted|>"`. But in the `SPECIAL_TOKEN_UUID` dict and `INCLUDE_SPECIAL_TOKENS` list, it is named `"<|end_untrusted|>"`.

This mismatch would cause a runtime error. 


The Argument Parser that has an incorrect prog name and description, if a user were to run the `--help` flag they would get the idea that this script is for validating the MXFP4 weights but it's not. 

## Change Made
This fix standardizes the name to `end_untrusted`, preventing the error.  The second change added the appropriate prog and description.