### PR TITLE
fix: Markdown linting and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ We're releasing two flavors of these open models:
 
 Both models were trained using our [harmony response format][harmony] and should only be used with this format; otherwise, they will not work correctly.
 
+## Table of Contents
+- [Highlights](#highlights)
+- [Inference examples](#inference-examples)
+- [About this repository](#about-this-repository)
+- [Setup](#setup)
+- [Download the model](#download-the-model)
+- [Reference PyTorch implementation](#reference-pytorch-implementation)
+- [Reference Triton implementation (single GPU)](#reference-triton-implementation-single-gpu)
+- [Reference Metal implementation](#reference-metal-implementation)
+- [Harmony format & tools](#harmony-format--tools)
+- [Clients](#clients)
+- [Tools](#tools)
+- [Other details](#other-details)
+- [Contributing](#contributing)
+
 ### Highlights
 
 - **Permissive Apache 2.0 license:** Build freely without copyleft restrictions or patent risk—ideal for experimentation, customization, and commercial deployment.

--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -40,7 +40,7 @@ This is a list of guides and resources to help you get started with the gpt-oss 
   - [Optimizing gpt-oss with NVIDIA TensorRT-LLM](https://cookbook.openai.com/articles/run-nvidia)
   - [Deploying gpt-oss on TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog9_Deploying_GPT_OSS_on_TRTLLM.md)
 - AMD
-  - [Running the Latest Open Models from OpenAI on AMD AI Hardware](https://rocm.blogs.amd.com/ecosystems-and-partners/openai-day-0/README.html)  
+  - [Running the Latest Open Models from OpenAI on AMD AI Hardware](https://rocm.blogs.amd.com/ecosystems-and-partners/openai-day-0/README.html)
 
 ### Cloud
 
@@ -49,18 +49,18 @@ This is a list of guides and resources to help you get started with the gpt-oss 
   - [gpt-oss-120b model on the GroqCloud Playground](https://console.groq.com/playground?model=openai/gpt-oss-120b)
   - [gpt-oss-20b model on the GroqCloud Playground](https://console.groq.com/playground?model=openai/gpt-oss-20b)
   - [gpt-oss with built-in web search on GroqCloud](https://console.groq.com/docs/browser-search)
-  - [gpt-oss with built-in code execution on GroqCloud](https://console.groq.com/docs/code-execution) 
+  - [gpt-oss with built-in code execution on GroqCloud](https://console.groq.com/docs/code-execution)
   - [Responses API on Groq](https://console.groq.com/docs/responses-api)
 - NVIDIA
   - [NVIDIA launch blog post](https://blogs.nvidia.com/blog/openai-gpt-oss/)
   - [NVIDIA & gpt-oss developer launch blog post](https://developer.nvidia.com/blog/delivering-1-5-m-tps-inference-on-nvidia-gb200-nvl72-nvidia-accelerates-openai-gpt-oss-models-from-cloud-to-edge/)
   - Use [gpt-oss-120b](https://build.nvidia.com/openai/gpt-oss-120b) and [gpt-oss-20b](https://build.nvidia.com/openai/gpt-oss-20b) on NVIDIA's Cloud
 - Cloudflare
-  - [Cloudflare & gpt-oss launch blog post](http://blog.cloudflare.com/openai-gpt-oss-on-workers-ai)
+  - [Cloudflare & gpt-oss launch blog post](https://blog.cloudflare.com/openai-gpt-oss-on-workers-ai)
   - [gpt-oss-120b on Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/gpt-oss-120b)
   - [gpt-oss-20b on Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/gpt-oss-20b)
 - AMD
-  - [gpt-oss-120B on AMD MI300X](https://huggingface.co/spaces/amd/gpt-oss-120b-chatbot) 
+  - [gpt-oss-120B on AMD MI300X](https://huggingface.co/spaces/amd/gpt-oss-120b-chatbot)
 
 ## Examples & Tutorials
 

--- a/gpt-oss-mcp-server/README.md
+++ b/gpt-oss-mcp-server/README.md
@@ -1,8 +1,8 @@
 # MCP Servers for gpt-oss reference tools
 
 This directory contains MCP servers for the reference tools in the [gpt-oss](https://github.com/openai/gpt-oss) repository.
-You can set up these tools behind MCP servers and use them in your applications. 
-For inference service that integrates with MCP, you can also use these as reference tools. 
+You can set up these tools behind MCP servers and use them in your applications.
+For inference service that integrates with MCP, you can also use these as reference tools.
 
 In particular, this directory contains a `build-system-prompt.py` script that will generate exactly the same system prompt as `reference-system-prompt.py`.
 The build system prompt script show case all the care needed to automatically discover the tools and construct the system prompt before feeding it into Harmony.
@@ -22,8 +22,8 @@ mcp run -t sse browser_server.py:mcp
 mcp run -t sse python_server.py:mcp
 ```
 
-You can now use MCP inspector to play with the tools. 
+You can now use MCP inspector to play with the tools.
 Once opened, set SSE to `http://localhost:8001/sse` and `http://localhost:8000/sse` respectively.
 
-To compare the system prompt and see how to construct it via MCP service discovery, see `build-system-prompt.py`. 
+To compare the system prompt and see how to construct it via MCP service discovery, see `build-system-prompt.py`.
 This script will generate exactly the same system prompt as `reference-system-prompt.py`.


### PR DESCRIPTION
This PR addresses minor formatting issues in Markdown files:

- Removes trailing whitespace to ensure consistent rendering.
- Updates an insecure http:// link to https:// for better security.