### PR TITLE
Fix editable build

### DIFF
--- a/_build/gpt_oss_build_backend/backend.py
+++ b/_build/gpt_oss_build_backend/backend.py
@@ -87,7 +87,7 @@ def prepare_metadata_for_build_wheel(
 # Optional hooks
 
 def build_editable(
-    editable_directory: str, config_settings: Mapping[str, Any] | None = None
+    editable_directory: str, config_settings: Mapping[str, Any] | None = None, metadata_directory: str | None = None
 ) -> str:
     be = _backend()
     fn = getattr(be, "build_editable", None)


### PR DESCRIPTION
According to https://peps.python.org/pep-0660/#build-editable , the function signature should be like 
```
def build_editable(
    editable_directory: str, config_settings: Mapping[str, Any] | None = None, metadata_directory: str | None = None
) -> str:
```

I can only run `uv pip install -e .` after this fix.