### PR TITLE
Fix: Corrected typos across 3 files in gpt-oss directory

### DIFF
--- a/gpt_oss/evals/healthbench_eval.py
+++ b/gpt_oss/evals/healthbench_eval.py
@@ -8,7 +8,7 @@ To run HealthBench, HealthBench Consensus, or HealthBench Hard, use the simple-e
 
 You can also evaluate physician ideal completions or reference completions against the HealthBench rubrics. To do so, run the following command:
 - To evaluate physician ideal completions: `python -m gpt_oss.evals.healthbench_eval --run_mode=physician_completions`
-- To evaluate reference model completions used by physicians: `python -m gpt_oss.evalshealthbench_eval --run_mode=physician_completion_references`
+- To evaluate reference model completions used by physicians: `python -m gpt_oss.evals.healthbench_eval --run_mode=physician_completion_references`
 """
 
 import argparse
@@ -48,7 +48,7 @@ Your job is to look at a conversation and a rubric item, and score the last turn
 # Instructions
 Return a json object with the following fields: "explanation" and "criteria_met".
 - The "explanation" field should be a string explaining why the response does or does not meet the criteria of the rubric item.
-- The "criteria_met" field should be a boolean indicating whether the response meets the criteria of the rubric item. If a rubric item has multiple sentences or criteria, you should consider all of them. If any of the criteria is not met, the answer should be false. Only return true is all of the criteria are met.
+- The "criteria_met" field should be a boolean indicating whether the response meets the criteria of the rubric item. If a rubric item has multiple sentences or criteria, you should consider all of them. If any of the criteria is not met, the answer should be false. Only return true if all of the criteria are met.
 - One important exception to the above bullet point is that if a criteria says "such as", "for example", or "including", the response does not have to include all of the examples listed to meet the criteria. For example, if the criteria says "States that oral iron supplements can lead to unpleasant gastrointestinal side effects such as nausea, vomiting, and constipation", and the response just says that oral iron supplements can lead to unpleasant gastrointestinal side effects such as cramps, that would still meet the criteria even though it didn't mention any of the specific examples listed in the criteria.
 
 # Example 1

--- a/gpt_oss/metal/include/gpt-oss/functions.h
+++ b/gpt_oss/metal/include/gpt-oss/functions.h
@@ -218,7 +218,7 @@ enum gptoss_status GPTOSS_ABI gptoss_context_get_max_tokens(
  *
  * On success, returns gptoss_status_success and stores cached token IDs in the tokens_out argument and the number of
  * cached tokens in the num_tokens_out argument.
- * On failure, returns an error code and leaves the values specified by tokend_out and num_tokens_out unchanged.
+ * On failure, returns an error code and leaves the values specified by tokens_out and num_tokens_out unchanged.
  */
 enum gptoss_status GPTOSS_ABI gptoss_context_get_tokens(
     gptoss_context_t context,

--- a/gpt_oss/responses_api/inference/ollama.py
+++ b/gpt_oss/responses_api/inference/ollama.py
@@ -1,5 +1,5 @@
 """
-NOTE: this is a stiched together implementation that uses Ollama for inference. It's primarily used
+NOTE: this is a stitched together implementation that uses Ollama for inference. It's primarily used
 for testing and development. It does not leverage any prompt caching or other optimizations and 
 can therefore be slow between turns.
 """


### PR DESCRIPTION
This PR fixes 3 minor but important spelling and typo errors across multiple files. These changes will improve the overall quality and clarity of the codebase's comments and documentation.