### PR TITLE
refactor: replace TextContent with SystemError in Tool class

### DIFF
--- a/gpt_oss/tools/tool.py
+++ b/gpt_oss/tools/tool.py
@@ -6,7 +6,7 @@ from openai_harmony import (
     Author,
     Role,
     Message,
-    TextContent,
+    SystemError,
 )
 
 
@@ -94,7 +94,7 @@ class Tool(ABC):
         return Message(
             id=id if id else uuid4(),
             author=Author(role=Role.TOOL, name=self.name),
-            content=TextContent(text=error_message), # TODO: Use SystemError instead
+            content=SystemError(error=error_message),
             channel=channel,
         ).with_recipient("assistant")
 


### PR DESCRIPTION
Updated the tool error helper to import and use SystemError instead of TextContent, so tool-generated failures now surface as system-level errors