### PR TITLE
fix: correct import statement for HTTPException in api_server.py

### DIFF
--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -789,7 +789,7 @@ def create_api_server(
 
                 reasoning_effort = get_reasoning_effort(body.reasoning.effect)
             except ValueError as e:
-                from fastapi import HTTP Exception
+                from fastapi import HTTPException
                 raise HTTPException(status_code=422, detail=str(e))
             system_message_content = system_message_content.with_reasoning_effort(reasoning_effort)
 


### PR DESCRIPTION
Corrected a FastAPI import by switching from a malformed `HTTP Exception` to the proper `HTTPException` to prevent syntax errors during server initialization