### PR TITLE
refactor: move maybe_truncate function to simple_browser_tool.py

### DIFF
--- a/gpt_oss/tools/simple_browser/backend.py
+++ b/gpt_oss/tools/simple_browser/backend.py
@@ -64,12 +64,6 @@ def with_retries(
         return func
 
 
-def maybe_truncate(text: str, num_chars: int = 1024) -> str:
-    if len(text) > num_chars:
-        text = text[: (num_chars - 3)] + "..."
-    return text
-
-
 @chz.chz(typecheck=True)
 class Backend:
     source: str = chz.field(doc="Description of the backend source")

--- a/gpt_oss/tools/simple_browser/simple_browser_tool.py
+++ b/gpt_oss/tools/simple_browser/simple_browser_tool.py
@@ -28,7 +28,6 @@ from .backend import (
     VIEW_SOURCE_PREFIX,
     Backend,
     BackendError,
-    maybe_truncate,
 )
 from .page_contents import Extract, PageContents
 
@@ -173,6 +172,11 @@ def wrap_lines(text: str, width: int = 80) -> list[str]:
         for line in lines
     )
     return list(wrapped)
+
+
+def maybe_truncate(text: str, num_chars: int = 1024) -> str:
+    """Truncate ``text`` to at most ``num_chars`` characters."""
+    return text if len(text) <= num_chars else text[: num_chars - 3] + "..."
 
 
 def strip_links(text: str) -> str:


### PR DESCRIPTION
- Removed the unused `maybe_truncate` helper from the backend to keep the module focused on backend logic only

- Localized truncation logic within `simple_browser_tool` by defining a dedicated `maybe_truncate` helper and updating imports accordingly