### PR TITLE
refactor: replace event loop with asyncio.to_thread in prompt_user function

### DIFF
--- a/examples/agents-sdk-python/example.py
+++ b/examples/agents-sdk-python/example.py
@@ -17,8 +17,7 @@ from agents.mcp import MCPServerStdio
 
 async def prompt_user(question: str) -> str:
     """Async input prompt function"""
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, input, question)
+    return await asyncio.to_thread(input, question)
 
 
 async def main():


### PR DESCRIPTION
Replaced the deprecated `asyncio.get_event_loop/run_in_executor` pattern with the modern `asyncio.to_thread` helper, simplifying asynchronous user input handling and aligning with current asyncio best practices

