### PR TITLE
feat: implement request_with_retry utility and refactor API calls

### DIFF
--- a/gpt_oss/responses_api/inference/ollama.py
+++ b/gpt_oss/responses_api/inference/ollama.py
@@ -8,7 +8,8 @@ import json
 import threading
 import time
 from typing import Callable, Optional
-import requests
+
+from gpt_oss.utils import request_with_retry
 
 from openai_harmony import load_harmony_encoding, HarmonyEncodingName
 
@@ -85,8 +86,10 @@ def setup_model(checkpoint: str) -> Callable[[list[int], float, bool], int]:
                     "options": {"temperature": temperature},
                 }
 
-                with requests.post(url, json=payload, stream=True, timeout=60) as resp:
-                    resp.raise_for_status()
+                resp = request_with_retry(
+                    "POST", url, json=payload, stream=True, timeout=60
+                )
+                with resp:
                     for line in resp.iter_lines(decode_unicode=True):
                         if not line:
                             continue

--- a/gpt_oss/utils/__init__.py
+++ b/gpt_oss/utils/__init__.py
@@ -1,0 +1,3 @@
+from .http import request_with_retry
+
+__all__ = ["request_with_retry"]

--- a/gpt_oss/utils/http.py
+++ b/gpt_oss/utils/http.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+from requests import RequestException, Response
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    max_retries: int = 3,
+    backoff_factor: float = 0.5,
+    **kwargs: Any,
+) -> Response:
+    for attempt in range(max_retries):
+        try:
+            response = requests.request(method, url, **kwargs)
+            response.raise_for_status()
+            return response
+        except RequestException:
+            if attempt == max_retries - 1:
+                raise
+            sleep_seconds = backoff_factor * (2 ** attempt)
+            time.sleep(sleep_seconds)
+
+    raise RuntimeError("request_with_retry failed unexpectedly")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,47 @@
+import requests
+from requests import Response, RequestException
+
+from gpt_oss.utils.http import request_with_retry
+
+
+def test_request_with_retry_success(monkeypatch):
+    calls = {"count": 0}
+    sleeps: list[float] = []
+
+    def fake_request(method, url, **kwargs):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise RequestException("boom")
+        resp = Response()
+        resp.status_code = 200
+        return resp
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("gpt_oss.utils.http.requests.request", fake_request)
+    monkeypatch.setattr("gpt_oss.utils.http.time.sleep", fake_sleep)
+
+    resp = request_with_retry("GET", "http://example.com", max_retries=3, backoff_factor=1)
+    assert resp.status_code == 200
+    assert calls["count"] == 3
+    assert sleeps == [1, 2]
+
+
+def test_request_with_retry_exhausts(monkeypatch):
+    calls = {"count": 0}
+
+    def always_fail(method, url, **kwargs):
+        calls["count"] += 1
+        raise RequestException("boom")
+
+    monkeypatch.setattr("gpt_oss.utils.http.requests.request", always_fail)
+    monkeypatch.setattr("gpt_oss.utils.http.time.sleep", lambda s: None)
+
+    try:
+        request_with_retry("GET", "http://example.com", max_retries=2, backoff_factor=0)
+    except RequestException:
+        pass
+    else:
+        assert False, "RequestException not raised"
+    assert calls["count"] == 2


### PR DESCRIPTION
- Introduced a reusable HTTP helper that retries requests with exponential backoff, providing configurable retry counts and delay factors for robust API interactions
- Updated the Ollama inference backend to route its streaming requests through the new retry helper, improving resilience during network hiccups
- Added tests