### PR TITLE
Fix start_q use in upper bound calculation

### DIFF
--- a/gpt_oss/triton/attention.py
+++ b/gpt_oss/triton/attention.py
@@ -111,9 +111,9 @@ def _attn_fwd(
     q = tl.load(Q_block_ptr)
 
     if BANDWIDTH:
-        lo, hi = tl.maximum(start_q, start_q + start_m * BLOCK_M - BANDWIDTH), (start_q + start_m + 1) * BLOCK_M
+        lo, hi = tl.maximum(start_q, start_q + start_m * BLOCK_M - BANDWIDTH), start_q + (start_m + 1) * BLOCK_M
     else:
-        lo, hi = start_q, (start_q + start_m + 1) * BLOCK_M
+        lo, hi = start_q, start_q + (start_m + 1) * BLOCK_M
 
     # advance the KV block-pointers so they point at `lo`
     K_block_ptr = tl.advance(K_block_ptr, (0, lo))


### PR DESCRIPTION
Noticed this suspicious use of `start_q` in the attention kernel. When calculating `lo`, `start_q` is not multiplied by `BLOCK_M` but when calculating `hi` it is despite both being in the same units.

Looking at how `start_q` is defined, it is defined entirely based on the tensor's shape and doesn't know about `BLOCK_M` so shouldn't be multiplied by `BLOCK_M`: https://github.com/openai/gpt-oss/blob/a02c2ce83e4c9b46773ff13c1eecf91b5d29a937/gpt_oss/triton/model.py#L153

Because the loading and computation are all masked, I don't think this effects numerics but it should reduce the number of iterations of the for loop.