### PR TITLE
Process tokens in Context lazily

### DIFF
--- a/gpt_oss/metal/source/include/internal/math.h
+++ b/gpt_oss/metal/source/include/internal/math.h
@@ -15,6 +15,10 @@ inline static size_t math_min(size_t a, size_t b) {
     return a < b ? a : b;
 }
 
+inline static size_t math_sub_sat(size_t a, size_t b) {
+    return a > b ? a - b : 0;
+}
+
 static size_t math_round_up_po2(size_t bytes, size_t multiple) {
     const size_t multiple_mask = multiple - 1;
     if ((bytes & multiple_mask) != 0) {

--- a/gpt_oss/metal/source/include/internal/model.h
+++ b/gpt_oss/metal/source/include/internal/model.h
@@ -114,13 +114,6 @@ struct gptoss_context {
     // Length of the context.
     size_t max_tokens;
 
-    // Current number of tokens in the batch.
-    // Always in the [0, max_batch_tokens) range.
-    size_t num_batch_tokens;
-    // Number of tokens processed in the last batch.
-    // Activations for [num_batch_tokens, num_processed_tokens) tokens can be accessed from internal structures.
-    size_t num_processed_tokens;
-
     size_t kvcache_size;
     size_t allocation_size;
 


### PR DESCRIPTION
- Process tokens when Context.process or Context.sample is called rather than when we accumulate max_batch_tokens unprocessed tokens.
- Avoid re-creating command buffers for each batch.
- Avoid redundantly computing output activations for the last token in each batch.
- Avoid invalidating KV cache on Context.reset. Match longest common prefix to tokens in KV cache when tokens are appended following Context.reset.