### PR TITLE
(feat): add warning log when failed on parsing tokens in api_server.py

### DIFF
--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -430,7 +430,8 @@ def create_api_server(
                 self.tokens.append(next_tok)
                 try:
                     self.parser.process(next_tok)
-                except Exception:
+                except Exception as e:
+                    print(f"Error parsing next tokens: {e}")
                     pass
 
                 if self.parser.state == StreamState.EXPECT_START:


### PR DESCRIPTION
## Description
Currently, we silently skip errors when `StreamableParser` failed to parse `next_tok` (generated by `infer_next_token`). Now we replace that with proper logging to indicate that when it failed.