### PR TITLE
Move Lemonade to AMD section of `awesome-gpt-oss`

### DIFF
--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -32,7 +32,6 @@ This is a list of guides and resources to help you get started with the gpt-oss 
   - [gpt-oss on RTX](https://blogs.nvidia.com/blog/rtx-ai-garage-openai-oss)
 - AMD
   - [Running gpt-oss models on AMD Ryzen AI Processors and Radeon Graphics Cards](https://www.amd.com/en/blogs/2025/how-to-run-openai-gpt-oss-20b-120b-models-on-amd-ryzen-ai-radeon.html)
-- Lemonade
   - [Running gpt-oss on STX Halo and Radeon dGPUs using Lemonade](https://lemonade-server.ai/news/gpt-oss.html)
 - llama.cpp
   - [Running gpt-oss with llama.cpp](https://github.com/ggml-org/llama.cpp/discussions/15396)


### PR DESCRIPTION
# Description

This PR moves Lemonade to the AMD section of `awesome-gpt-oss`.

This change is due to internal AMD guidance to improve clarity.