### PR TITLE
Remove requirement on maximum Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "termcolor",
 ]
 readme = "README.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12"
 version = "0.0.5"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Codebase works fine with CPython 3.13, and the current stable is 3.13.7, so no good reason to restrict that