### PR TITLE
Adding prefill benchmarking for metal backend

### DIFF
--- a/gpt_oss/metal/benchmark/end-to-end.cc
+++ b/gpt_oss/metal/benchmark/end-to-end.cc
@@ -2,9 +2,10 @@
 #include <internal/model.h>
 
 #include <array>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <format>
+#include <fstream>
 #include <limits>
 #include <memory>
 #include <string>
@@ -12,11 +13,9 @@
 
 #include <benchmark/benchmark.h>
 
-
 constexpr std::uint32_t kNumGeneratedTokens = 100;
 
-
-static void end2end(benchmark::State& state, const char* env_var_name) {
+static void end2end_decode(benchmark::State& state, const char* env_var_name) {
     const char* model_path = getenv(env_var_name);
     if (model_path == NULL) {
         state.SkipWithError(std::format("environment variable {} is not set", env_var_name));
@@ -24,7 +23,7 @@ static void end2end(benchmark::State& state, const char* env_var_name) {
     }
 
     gptoss_model_t model_ptr = nullptr;
-    gptoss_status status = gptoss_model_create_from_file(model_path, &model_ptr);
+    gptoss_status status = gptoss_model_create_from_file(model_path, &model_ptr, 0);
     if (status != gptoss_status_success) {
         state.SkipWithError(std::format("failed to load model from file {}", model_path));
         return;
@@ -66,7 +65,7 @@ static void end2end(benchmark::State& state, const char* env_var_name) {
         do {
             std::size_t num_current_generated_tokens = 0;
             status = gptoss_context_sample(context.get(), /*temperature=*/1.0f, /*rng_state=*/current_rng_seed,
-                /*max_tokens=*/kNumGeneratedTokens - num_generated_tokens, tokens.data(), &num_current_generated_tokens);
+                                           /*max_tokens=*/kNumGeneratedTokens - num_generated_tokens, tokens.data(), &num_current_generated_tokens);
             if (status != gptoss_status_success) {
                 state.SkipWithError("failed to sample from the Context object");
                 return;
@@ -85,7 +84,7 @@ static void end2end(benchmark::State& state, const char* env_var_name) {
         do {
             std::size_t num_current_generated_tokens = 0;
             status = gptoss_context_sample(context.get(), /*temperature=*/1.0f, /*rng_state=*/current_rng_seed,
-                /*max_tokens=*/kNumGeneratedTokens - num_generated_tokens, tokens.data(), &num_current_generated_tokens);
+                                           /*max_tokens=*/kNumGeneratedTokens - num_generated_tokens, tokens.data(), &num_current_generated_tokens);
             if (status != gptoss_status_success) {
                 state.SkipWithError("failed to sample from the Context object");
                 return;
@@ -100,9 +99,143 @@ static void end2end(benchmark::State& state, const char* env_var_name) {
         benchmark::Counter(state.iterations() * kNumGeneratedTokens, benchmark::Counter::kIsRate);
 }
 
-BENCHMARK_CAPTURE(end2end, gpt_oss_20b, "GPT_OSS_20B_PATH")
-    ->UseRealTime()->Unit(benchmark::kMillisecond);
-BENCHMARK_CAPTURE(end2end, gpt_oss_120b, "GPT_OSS_120B_PATH")
-    ->UseRealTime()->Unit(benchmark::kMillisecond);
+static void end2end_prefill(benchmark::State& state,
+                            const char* model_path_env_var_name,
+                            const char* prompt_env_var_name,
+                            size_t context_length = 0) {
+    const char* model_path = getenv(model_path_env_var_name);
+    if (model_path == NULL) {
+        state.SkipWithError(std::format("environment variable {} is not set",
+                                        model_path_env_var_name));
+        return;
+    }
+
+    const char* prompt_file_path = getenv(prompt_env_var_name);
+    if (prompt_file_path == NULL) {
+        state.SkipWithError(std::format("environment variable {} is not set",
+                                        prompt_env_var_name));
+        return;
+    }
+
+    // Read prompt contents from file into a std::string
+    std::ifstream prompt_file(prompt_file_path,
+                              std::ios::in | std::ios::binary);
+    if (!prompt_file) {
+        state.SkipWithError(
+            std::format("failed to open prompt file {}", prompt_file_path));
+        return;
+    }
+    std::string prompt_str;
+    prompt_file.seekg(0, std::ios::end);
+    std::streampos file_size = prompt_file.tellg();
+    if (file_size < 0) {
+        state.SkipWithError(std::format("failed to read prompt file size {}",
+                                        prompt_file_path));
+        return;
+    }
+    prompt_str.resize(static_cast<std::size_t>(file_size));
+    prompt_file.seekg(0, std::ios::beg);
+    if (file_size > 0) {
+        prompt_file.read(prompt_str.data(), file_size);
+    }
+    if (!prompt_file) {
+        state.SkipWithError(
+            std::format("failed to read prompt file {}", prompt_file_path));
+        return;
+    }
+
+    gptoss_model_t model_ptr = nullptr;
+    gptoss_status status =
+        gptoss_model_create_from_file(model_path, &model_ptr, 1024);
+    if (status != gptoss_status_success) {
+        state.SkipWithError(
+            std::format("failed to load model from file {}", model_path));
+        return;
+    }
+    std::unique_ptr<std::remove_pointer_t<gptoss_model_t>,
+                    decltype(&gptoss_model_release)>
+        model(model_ptr, gptoss_model_release);
+
+    gptoss_tokenizer_t tokenizer_ptr = nullptr;
+    status = gptoss_model_get_tokenizer(model.get(), &tokenizer_ptr);
+    if (status != gptoss_status_success) {
+        state.SkipWithError("failed to retrieve Tokenizer");
+        return;
+    }
+    std::unique_ptr<std::remove_pointer_t<gptoss_tokenizer_t>,
+                    decltype(&gptoss_tokenizer_release)>
+        tokenizer(tokenizer_ptr, gptoss_tokenizer_release);
+
+    gptoss_context_t context_ptr = nullptr;
+    status =
+        gptoss_context_create(model.get(), /*context_lenght=*/0, &context_ptr);
+    if (status != gptoss_status_success) {
+        state.SkipWithError("failed to create Context object");
+        return;
+    }
+    std::unique_ptr<std::remove_pointer_t<gptoss_context_t>,
+                    decltype(&gptoss_context_release)>
+        context(context_ptr, gptoss_context_release);
+
+    const char* prompt = prompt_str.c_str();
+    status = gptoss_context_append_chars(context.get(), prompt,
+                                         prompt_str.size(), nullptr);
+    if (status != gptoss_status_success) {
+        state.SkipWithError(std::format(
+            "failed to tokenize prompt from file {}", prompt_file_path));
+        return;
+    }
+
+    size_t num_tokens;
+    status = gptoss_context_get_num_tokens(context.get(), &num_tokens);
+    if (status != gptoss_status_success) {
+        state.SkipWithError("failed to get number of tokens");
+        return;
+    }
+    if (context_length != 0) {
+        assert(context_length <= num_tokens);
+        context->num_tokens = context_length;
+    }
+    // Prefill
+    for (auto _ : state) {
+        status = gptoss_context_process(context.get());
+        if (status != gptoss_status_success) {
+            state.SkipWithError("failed to prefill Context object");
+            return;
+        }
+        context->num_kv_tokens = 0;
+    }
+
+    state.counters["tokens"] = num_tokens;
+    state.counters["tokens/s"] = benchmark::Counter(
+        state.iterations() * num_tokens, benchmark::Counter::kIsRate);
+}
+
+// Decode end-to-end benchmark
+BENCHMARK_CAPTURE(end2end_decode, gpt_oss_20b_decode, "GPT_OSS_20B_PATH")
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(end2end_decode, gpt_oss_120b_decode, "GPT_OSS_120B_PATH")
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+
+// Prefill end-to-end benchmark
+BENCHMARK_CAPTURE(end2end_prefill, gpt_oss_120b_prefill_1024,
+                  "GPT_OSS_120B_PATH", "GPT_OSS_PROMPT_FILE_PATH", 1024)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(end2end_prefill, gpt_oss_20b_prefill_1024, "GPT_OSS_20B_PATH",
+                  "GPT_OSS_PROMPT_FILE_PATH", 1024)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(end2end_prefill, gpt_oss_120b_prefill_3072,
+                  "GPT_OSS_120B_PATH", "GPT_OSS_PROMPT_FILE_PATH", 3072)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(end2end_prefill, gpt_oss_20b_prefill_3072, "GPT_OSS_20B_PATH",
+                  "GPT_OSS_PROMPT_FILE_PATH", 3072)
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/gpt_oss/metal/include/gpt-oss/functions.h
+++ b/gpt_oss/metal/include/gpt-oss/functions.h
@@ -15,13 +15,17 @@ extern "C" {
  *
  * @param path Path to the file containing the model in GPT-OSS format.
  * @param model_out Pointer to the Model object that will be created. Must be released with gptoss_release_model.
+ * @param max_batch_tokens Maximum number of tokens that can be processed in a single batch.
+ *                        Larger values may improve prefill performance, but require more memory.
+ *                        Specify 0 to use the default value.
  *
  * On success, returns gptoss_status_success and saves a pointer to the created Model in the model_out argument.
  * On failure, returns an error code and stores null pointer in the model_out argument.
  */
 enum gptoss_status GPTOSS_ABI gptoss_model_create_from_file(
     const char* path,
-    gptoss_model_t* model_out);
+    gptoss_model_t* model_out,
+    size_t max_batch_tokens);
 
 /*
  * Query the Tokenizer object associated with the Model.

--- a/gpt_oss/metal/python/model.c
+++ b/gpt_oss/metal/python/model.c
@@ -12,7 +12,7 @@ static int PyGPTOSSModel_init(PyGPTOSSModel* self, PyObject* args, PyObject* kwa
     if (!PyArg_ParseTuple(args, "s", &filepath)) {
         return -1;
     }
-    status = gptoss_model_create_from_file(filepath, &self->handle);
+    status = gptoss_model_create_from_file(filepath, &self->handle, 0);
     if (status != gptoss_status_success) {
         // TODO: set exception
         return -1;

--- a/gpt_oss/metal/source/generate.c
+++ b/gpt_oss/metal/source/generate.c
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
     struct options options = parse_options(argc, argv);
 
     const uint64_t load_start_time = mach_continuous_time();
-    status = gptoss_model_create_from_file(options.model, &model);
+    status = gptoss_model_create_from_file(options.model, &model, 0);
     if (status != gptoss_status_success) {
         fprintf(stderr, "Error: failed to load model from file %s\n", options.model);
         goto error;

--- a/gpt_oss/metal/source/model.c
+++ b/gpt_oss/metal/source/model.c
@@ -79,7 +79,8 @@ static void prefetch_fd(int fd, size_t offset, size_t size, const char* path) {
 
 enum gptoss_status GPTOSS_ABI gptoss_model_create_from_file(
     const char* path,
-    gptoss_model_t* model_out)
+    gptoss_model_t* model_out,
+    size_t max_batch_tokens)
 {
     *model_out = NULL;
 
@@ -192,7 +193,7 @@ enum gptoss_status GPTOSS_ABI gptoss_model_create_from_file(
     model->yarn_multiplier = model_header.yarn_multiplier;
     model->rmsnorm_epsilon = model_header.rmsnorm_epsilon;
 
-    model->max_batch_tokens = GPTOSS_DEFAULT_BATCH_SIZE;
+    model->max_batch_tokens = max_batch_tokens == 0 ? GPTOSS_DEFAULT_BATCH_SIZE : max_batch_tokens;
 
     struct gptoss_uuid tokenizer_uuid;
     status = read_fd(fd, &tokenizer_uuid, sizeof(tokenizer_uuid), path);


### PR DESCRIPTION
Adds prefill benchmarking for Metal backend. Users will need to set an environment variable with the path to the prompt that will be tested:
`export GPT_OSS_PROMPT_FILE_PATH=<path_to_text_file_with_prompt>`