### PR TITLE
[Bugfix]Capture stderr for python tool with uv as backend

### DIFF
--- a/gpt_oss/tools/python_docker/docker_tool.py
+++ b/gpt_oss/tools/python_docker/docker_tool.py
@@ -78,7 +78,11 @@ def call_python_script_with_uv(script: str) -> str:
         exec_result = subprocess.run(
             ["uv", "run", "--no-project", "python", script_path],
             capture_output=True)
-        return exec_result.stdout.decode("utf-8")
+        return (
+            exec_result.stdout.decode("utf-8")
+            if exec_result.returncode == 0
+            else exec_result.stderr.decode("utf-8")
+        )
 
 
 class PythonTool(Tool):


### PR DESCRIPTION
When using uv as python execution backend, we only capture stdout for output. But there are errors in python code generated by gpt-oss sometimes. We should capture error message from stderr channel of subprocess as output of python tool.