### PR TITLE
Adding metal moe kernels for prefill

### DIFF
--- a/gpt_oss/metal/CMakeLists.txt
+++ b/gpt_oss/metal/CMakeLists.txt
@@ -17,12 +17,14 @@ set(METAL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/source/accumulate.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/convert.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/embeddings.metal
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/gather_and_accumulate.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/matmul.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/moematmul.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/random.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/rmsnorm.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/rope.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/sample.metal
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/scatter.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/sdpa.metal
     ${CMAKE_CURRENT_SOURCE_DIR}/source/topk.metal
 )
@@ -38,13 +40,15 @@ add_custom_command(
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/embeddings.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/embeddings.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/matmul.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/matmul.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/moematmul.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/moematmul.air"
+    COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/gather_and_accumulate.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/gather_and_accumulate.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/random.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/random.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/rmsnorm.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/rmsnorm.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/rope.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/rope.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/sample.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/sample.air"
+    COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/scatter.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/scatter.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/sdpa.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/sdpa.air"
     COMMAND xcrun -sdk macosx metal -g "-I${CMAKE_CURRENT_SOURCE_DIR}/source/include" -c "${CMAKE_CURRENT_SOURCE_DIR}/source/topk.metal" -o "${CMAKE_CURRENT_BINARY_DIR}/source/topk.air"
-    COMMAND xcrun -sdk macosx metallib "${CMAKE_CURRENT_BINARY_DIR}/source/accumulate.air" "${CMAKE_CURRENT_BINARY_DIR}/source/convert.air" "${CMAKE_CURRENT_BINARY_DIR}/source/embeddings.air" "${CMAKE_CURRENT_BINARY_DIR}/source/matmul.air" "${CMAKE_CURRENT_BINARY_DIR}/source/moematmul.air" "${CMAKE_CURRENT_BINARY_DIR}/source/random.air" "${CMAKE_CURRENT_BINARY_DIR}/source/rmsnorm.air" "${CMAKE_CURRENT_BINARY_DIR}/source/rope.air" "${CMAKE_CURRENT_BINARY_DIR}/source/sample.air"  "${CMAKE_CURRENT_BINARY_DIR}/source/sdpa.air" "${CMAKE_CURRENT_BINARY_DIR}/source/topk.air" -o "${METAL_LIB}"
+    COMMAND xcrun -sdk macosx metallib "${CMAKE_CURRENT_BINARY_DIR}/source/accumulate.air" "${CMAKE_CURRENT_BINARY_DIR}/source/convert.air" "${CMAKE_CURRENT_BINARY_DIR}/source/embeddings.air" "${CMAKE_CURRENT_BINARY_DIR}/source/gather_and_accumulate.air" "${CMAKE_CURRENT_BINARY_DIR}/source/matmul.air" "${CMAKE_CURRENT_BINARY_DIR}/source/moematmul.air" "${CMAKE_CURRENT_BINARY_DIR}/source/random.air" "${CMAKE_CURRENT_BINARY_DIR}/source/rmsnorm.air" "${CMAKE_CURRENT_BINARY_DIR}/source/rope.air" "${CMAKE_CURRENT_BINARY_DIR}/source/sample.air" "${CMAKE_CURRENT_BINARY_DIR}/source/scatter.air" "${CMAKE_CURRENT_BINARY_DIR}/source/sdpa.air" "${CMAKE_CURRENT_BINARY_DIR}/source/topk.air" -o "${METAL_LIB}"
     DEPENDS ${METAL_SOURCES}
     COMMENT "Compiling Metal compute library"
 )

--- a/gpt_oss/metal/benchmark/end-to-end.cc
+++ b/gpt_oss/metal/benchmark/end-to-end.cc
@@ -176,6 +176,11 @@ static void end2end_prefill(benchmark::State& state,
         assert(context_length <= num_tokens);
         context->num_tokens = context_length;
     }
+    status = gptoss_context_get_num_tokens(context.get(), &num_tokens);
+    if (status != gptoss_status_success) {
+        state.SkipWithError("failed to get number of tokens");
+        return;
+    }
     // Prefill
     for (auto _ : state) {
         status = gptoss_context_process(context.get());

--- a/gpt_oss/metal/source/gather_and_accumulate.metal
+++ b/gpt_oss/metal/source/gather_and_accumulate.metal
@@ -1,0 +1,74 @@
+#include <internal/kernel-args.h>
+#include <metal_integer>
+#include <metal_math>
+#include <metal_stdlib>
+
+// TODO(ibrahim): This is not optimal as each thread only gathers and accumulates a single float4. To amortize the
+// cost of reading the expert, offset and scales for a token, we should let each thread gather and accumulate several
+// float4s.
+kernel void gptoss_f32_gather_and_accumulate_e4(
+    constant gptoss_gather_args& args [[ buffer(0) ]],
+    const device float* in [[ buffer(1) ]],
+    const device gptoss_expert_prediction* __restrict__ expert_predictions [[ buffer(2) ]],
+    const device uint* expert_offsets [[ buffer(3) ]],
+    const device uint* intra_expert_offsets [[ buffer(4) ]],
+    device float* out [[ buffer(5) ]],
+    uint3 gid [[thread_position_in_grid]]) 
+{
+    const uint T = args.tokens;
+    const uint k = args.active_experts_per_token;
+    const uint D = args.token_stride;
+
+    assert((D & 3u) == 0);
+    assert(k == 4);
+
+    const uint row = gid.y;
+    if (row >= T) {
+        return;
+    }
+
+    const uint col_vec4 = gid.x;
+    const uint col = col_vec4 * 4u;
+    if (col >= D) {
+        return;
+    }
+
+    device float4* dst4 = reinterpret_cast<device float4*>(out + row * D + col);
+
+    const uint base = row * k;
+    const gptoss_expert_prediction expert0 = expert_predictions[base];
+    const gptoss_expert_prediction expert1 = expert_predictions[base + 1];
+    const gptoss_expert_prediction expert2 = expert_predictions[base + 2];
+    const gptoss_expert_prediction expert3 = expert_predictions[base + 3];
+    const uint expert0_id = expert0.expert_id;
+    const uint expert1_id = expert1.expert_id;
+    const uint expert2_id = expert2.expert_id;
+    const uint expert3_id = expert3.expert_id;
+    const float scale0 = expert0.score;
+    const float scale1 = expert1.score;
+    const float scale2 = expert2.score;
+    const float scale3 = expert3.score;
+    const uint4 current_intra_expert_offsets =
+        *reinterpret_cast<const device uint4*>(&intra_expert_offsets[base]);
+    // Get the row indices for the current expert ids
+    const uint r0 = expert_offsets[expert0_id] + current_intra_expert_offsets.x;
+    const uint r1 = expert_offsets[expert1_id] + current_intra_expert_offsets.y;
+    const uint r2 = expert_offsets[expert2_id] + current_intra_expert_offsets.z;
+    const uint r3 = expert_offsets[expert3_id] + current_intra_expert_offsets.w;
+
+    const device float4* src0 =
+        reinterpret_cast<const device float4*>(in + r0 * D + col);
+    const device float4* src1 =
+        reinterpret_cast<const device float4*>(in + r1 * D + col);
+    const device float4* src2 =
+        reinterpret_cast<const device float4*>(in + r2 * D + col);
+    const device float4* src3 =
+        reinterpret_cast<const device float4*>(in + r3 * D + col);
+
+    float4 acc = *dst4;
+    acc = metal::fma(*src0, scale0, acc);
+    acc = metal::fma(*src1, scale1, acc);
+    acc = metal::fma(*src2, scale2, acc);
+    acc = metal::fma(*src3, scale3, acc);
+    *dst4 = acc;
+}

--- a/gpt_oss/metal/source/include/internal/kernel-args.h
+++ b/gpt_oss/metal/source/include/internal/kernel-args.h
@@ -23,6 +23,18 @@
 #define MLP_GATE_Sg_Bm 16
 #define MLP_GATE_Sg_Bn 16
 
+#define MOE_DENSE_MATMUL_SWIGLU_Bm 32
+#define MOE_DENSE_MATMUL_SWIGLU_Bn 64
+#define MOE_DENSE_MATMUL_SWIGLU_Bk 16
+#define MOE_DENSE_MATMUL_SWIGLU_Sg_Bm 32
+#define MOE_DENSE_MATMUL_SWIGLU_Sg_Bn 16
+
+#define MOE_DENSE_MATMUL_Bm 32
+#define MOE_DENSE_MATMUL_Bn 64
+#define MOE_DENSE_MATMUL_Bk 16
+#define MOE_DENSE_MATMUL_Sg_Bm 32
+#define MOE_DENSE_MATMUL_Sg_Bn 16
+
 struct gptoss_expert_prediction {
     uint32_t expert_id;
     float score;
@@ -90,6 +102,41 @@ struct gptoss_dense_matmul_args {
     uint32_t m;
     uint32_t n;
     uint32_t k;
+};
+
+struct gptoss_scatter_args {
+    uint32_t tokens;
+    uint32_t active_experts_per_token;
+    uint32_t token_stride;
+};
+
+struct gptoss_moe_dense_matmul_swiglu_args {
+    uint32_t expert_token_count;
+    uint32_t k;
+    uint32_t n;
+    uint32_t expert_id;
+    uint32_t expert_token_offset;
+    uint32_t weight_blocks_expert_stride_bytes;
+    uint32_t weight_scales_expert_stride_bytes;
+    uint32_t bias_expert_stride_bytes;
+    float swiglu_min;
+    float swiglu_max;
+};
+struct gptoss_moe_dense_matmul_args {
+    uint32_t expert_token_count;
+    uint32_t k;
+    uint32_t n;
+    uint32_t expert_id;
+    uint32_t expert_token_offset;
+    uint32_t weight_blocks_expert_stride_bytes;
+    uint32_t weight_scales_expert_stride_bytes;
+    uint32_t bias_expert_stride_bytes;
+};
+
+struct gptoss_gather_args {
+    uint32_t tokens;
+    uint32_t active_experts_per_token;
+    uint32_t token_stride;
 };
 
 struct gptoss_unembedding_args {

--- a/gpt_oss/metal/source/moematmul.metal
+++ b/gpt_oss/metal/source/moematmul.metal
@@ -1,13 +1,13 @@
+#include <internal/kernel-args.h>
 #include <metal_common>
 #include <metal_compute>
 #include <metal_math>
 #include <metal_simdgroup>
-
-#include <internal/kernel-args.h>
+#include <metal_stdlib>
 
 #pragma METAL fp math_mode(safe)
 #pragma METAL fp contract(off)
-
+#define ceil_div(a, b) (((a) + (b) - 1) / (b))
 
 // Each simdgroup reduces all channels of the input and computes a single channel of the output
 // + Efficient synchronization
@@ -222,5 +222,479 @@ kernel void gptoss_f32_mf4w_moe_matmul(
     if (metal::simd_is_first()) {
         sum += static_cast<float>(*bias);
         *output = sum;
+    }
+}
+
+kernel void gptoss_f32_mf4w_moe_dense_matmul_swiglu(
+    constant gptoss_moe_dense_matmul_swiglu_args& params [[ buffer(0) ]],
+    const device float* lhs [[ buffer(1) ]],
+    const device uint* weight_blocks [[ buffer(2) ]],
+    const device uchar* weight_scales [[ buffer(3) ]],
+    const device bfloat* __restrict__ bias [[ buffer(4) ]],
+    device float* out [[ buffer(5) ]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint3 threads_per_tg [[threads_per_threadgroup]],
+    uint sg_count_per_tg [[dispatch_simdgroups_per_threadgroup]],
+    uint3 gid [[thread_position_in_grid]],
+    uint3 tg_id [[threadgroup_position_in_grid]],
+    uint3 local_tid [[thread_position_in_threadgroup]]) 
+{
+    constexpr uint Bm = MOE_DENSE_MATMUL_SWIGLU_Bm;
+    constexpr uint Bn = MOE_DENSE_MATMUL_SWIGLU_Bn;
+    constexpr uint Bk = MOE_DENSE_MATMUL_SWIGLU_Bk;
+    constexpr uint Sg_Bm = MOE_DENSE_MATMUL_SWIGLU_Sg_Bm;
+    constexpr uint Sg_Bn = MOE_DENSE_MATMUL_SWIGLU_Sg_Bn;
+
+    // Assumptions about shapes.
+    assert(Bm % 8 == 0);
+    assert(Bn % 8 == 0);
+    assert(Bk % 8 == 0);
+    assert(Sg_Bm % 8 == 0);
+    assert(Sg_Bn % 8 == 0);
+    assert(Bm % Sg_Bm == 0);
+    assert(Bn % Sg_Bn == 0);
+
+    const uint K = params.k;
+    const uint N = params.n;
+    const uint M = params.expert_token_count;
+    assert((K % 32) == 0);
+    assert((K % 8) == 0);
+    assert(N % Bn == 0);
+    assert(K % Bk == 0);
+    // Get row and col tg.
+    const uint row_tg = tg_id.y;
+    const uint col_tg = tg_id.x;
+    // Get row and col local tid.
+    const uint row_tg_offset = row_tg * Bm;
+    const uint col_tg_offset = col_tg * Bn;
+    if (row_tg_offset >= M || col_tg_offset >= N) {
+        return;
+    }
+    // Move lhs and output according to the passed offset.
+    lhs += params.expert_token_offset * K;
+    const uint N_output = N / 2;
+    out += params.expert_token_offset * N_output;
+
+    const uint e = params.expert_id;
+    const uint S = params.weight_blocks_expert_stride_bytes;
+    const uint S_scales = params.weight_scales_expert_stride_bytes;
+    const uint S_bias = params.bias_expert_stride_bytes;
+
+    const device char* wb0 = reinterpret_cast<const device char*>(weight_blocks);
+    const device char* sc0 = reinterpret_cast<const device char*>(weight_scales);
+    const device char* bi0 = reinterpret_cast<const device char*>(bias);
+
+    weight_blocks = reinterpret_cast<const device uint*>(wb0 + e * S);
+    weight_scales = reinterpret_cast<const device uchar*>(sc0 + e * S_scales);
+    bias = reinterpret_cast<const device bfloat*>(bi0 + e * S_bias);
+
+    const uint sg_col_count = Bn / Sg_Bn;
+    const uint row_sg = sg_id / sg_col_count;
+    const uint col_sg = sg_id % sg_col_count;
+
+    const uint row_sg_offset = row_sg * Sg_Bm;
+    const uint col_sg_offset = col_sg * Sg_Bn;
+    // Declare threadgroup blocks.
+    threadgroup float lhs_block[Bm * Bk];
+    // rhs_block will hold the scaled fp32 weights.
+    threadgroup float rhs_block[Bn * Bk];
+
+    constexpr uint temp_result_size = (Sg_Bm / 8) * (Sg_Bn / 8);
+    // Create an array of simdgroup_float8x8 to hold temp results.
+    metal::simdgroup_float8x8 OutTiles[temp_result_size];
+    for (uint i = 0; i < temp_result_size; i++) {
+        OutTiles[i] = metal::make_filled_simdgroup_matrix<float, 8, 8>(0.0);
+    }
+    // Linear thread id within TG (we launch 1-D TGs)
+    const uint lin_tid = local_tid.x;
+    const uint thread_count_per_tg = threads_per_tg.x * threads_per_tg.y * threads_per_tg.z;
+
+    // Iterate over all Bk blocks.
+    for (uint k_offset = 0; k_offset < K; k_offset += Bk) {
+        constexpr uint lhs_row_stride = Bk;
+        constexpr uint lhs_vec_cols = Bk / 4;
+        constexpr uint lhs_vec_total = Bm * lhs_vec_cols;
+
+        const uint LHS_ITERS = ceil_div(lhs_vec_total, thread_count_per_tg);
+
+        // #pragma clang loop unroll(full)
+        for (uint t = 0; t < LHS_ITERS; ++t) {
+            const uint i = t * thread_count_per_tg + lin_tid;
+            if (i < lhs_vec_total) {
+                const uint r = i / lhs_vec_cols;
+                const uint c4 = i % lhs_vec_cols;
+
+                const uint gr = row_tg_offset + r;
+                const uint gc4 = (k_offset / 4) + c4;
+
+                threadgroup float4* dst4 =
+                    reinterpret_cast<threadgroup float4*>(lhs_block + r * lhs_row_stride + (c4 << 2));
+                if (gr < M) {
+                    const device float4* src4 =
+                        reinterpret_cast<const device float4*>(lhs + gr * K + (gc4 << 2));
+
+                    *dst4 = *src4;
+                } else {
+                    *dst4 = float4(0.0);
+                }
+            }
+        }
+
+        // Load weights with vector loads.
+        constexpr uint rhs_row_stride = Bk;
+        constexpr uint weights_per_elem = 8;
+        constexpr uint rhs_loads_per_col = Bk / weights_per_elem;
+        constexpr uint rhs_loads_total = Bn * rhs_loads_per_col;
+        const uint RHS_ITERS = ceil_div(rhs_loads_total, thread_count_per_tg);
+        // #pragma clang loop unroll(full)
+        for (uint t = 0; t < RHS_ITERS; ++t) {
+            const uint i = t * thread_count_per_tg + lin_tid;
+            if (i < rhs_loads_total) {
+                const uint r = i / rhs_loads_per_col;
+                const uint c = i % rhs_loads_per_col;
+
+                const uint gr = col_tg_offset + r;
+                const uint gc = (k_offset / weights_per_elem) + c;
+                const uint gc_scale = (k_offset / 32) + (c >> 2);
+
+                const uint wblock = weight_blocks[gr * (K / weights_per_elem) + gc];
+                const float scale =
+                    as_type<float>(static_cast<uint>(weight_scales[gr * (K / 32) + gc_scale]) << 23);
+                uint wblock0246 = (wblock + wblock);
+                uint wblock1357 = (wblock >> 3);
+                wblock0246 &= 0x1E1E1E1Eu;
+                wblock1357 &= 0x1E1E1E1Eu;
+
+                wblock0246 += 0x70707070u;
+                wblock1357 += 0x70707070u;
+                wblock0246 &= 0x8E8E8E8Eu;
+                wblock1357 &= 0x8E8E8E8Eu;
+
+                uint wblock26 = (wblock0246) & 0xFF00FF00u;
+                uint wblock04 = ((wblock0246 << 8)) & 0xFF00FF00u;
+                uint wblock37 = (wblock1357) & 0xFF00FF00u;
+                uint wblock15 = ((wblock1357 << 8)) & 0xFF00FF00u;
+
+                half4 wblock0426 = as_type<half4>(uint2(wblock04, wblock26));
+                half4 wblock1537 = as_type<half4>(uint2(wblock15, wblock37));
+
+                // Convert to float scalars and apply scale
+                const float w0 = float(wblock0426.x) * scale;
+                const float w1 = float(wblock1537.x) * scale;
+                const float w2 = float(wblock0426.z) * scale;
+                const float w3 = float(wblock1537.z) * scale;
+                const float w4 = float(wblock0426.y) * scale;
+                const float w5 = float(wblock1537.y) * scale;
+                const float w6 = float(wblock0426.w) * scale;
+                const float w7 = float(wblock1537.w) * scale;
+                const uint rhs_offset = r * rhs_row_stride + c * 8;
+                rhs_block[rhs_offset] = w0;
+                rhs_block[rhs_offset + 1] = w1;
+                rhs_block[rhs_offset + 2] = w2;
+                rhs_block[rhs_offset + 3] = w3;
+                rhs_block[rhs_offset + 4] = w4;
+                rhs_block[rhs_offset + 5] = w5;
+                rhs_block[rhs_offset + 6] = w6;
+                rhs_block[rhs_offset + 7] = w7;
+            }
+        }
+        threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+#pragma clang loop unroll(full)
+        for (uint k = 0; k < Bk; k += 8) {
+#pragma clang loop unroll(full)
+            for (uint m_subtile_ = 0; m_subtile_ < Sg_Bm; m_subtile_ += 8) {
+                const uint row_index_in_out_tile = m_subtile_ / 8;
+                metal::simdgroup_float8x8 lhs_frag;
+
+                simdgroup_load(lhs_frag, lhs_block, Bk, ulong2(k, m_subtile_ + row_sg_offset));
+#pragma clang loop unroll(full)
+                for (uint n_subtile_ = 0; n_subtile_ < Sg_Bn; n_subtile_ += 8) {
+                    const uint col_index_in_out_tile = n_subtile_ / 8;
+                    const uint current_index_out_tile =
+                        row_index_in_out_tile * (Sg_Bn / 8) + col_index_in_out_tile;
+                    metal::simdgroup_float8x8 rhs_frag;
+                    simdgroup_load(rhs_frag, rhs_block, Bk, ulong2(k, n_subtile_ + col_sg_offset), true);
+
+                    simdgroup_multiply_accumulate(OutTiles[current_index_out_tile], lhs_frag, rhs_frag,
+                        OutTiles[current_index_out_tile]);
+                }
+            }
+        }
+        threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    }
+
+    // Epilogue.
+    threadgroup float scratch[Bm * Bn];
+#pragma clang loop unroll(full)
+    for (uint n_subtile_ = 0; n_subtile_ < Sg_Bn; n_subtile_ += 8) {
+        const uint col_index_in_out_tile = n_subtile_ / 8;
+        const uint local_col_offset = col_sg_offset + n_subtile_;
+#pragma clang loop unroll(full)
+        for (uint m_subtile_ = 0; m_subtile_ < Sg_Bm; m_subtile_ += 8) {
+            const uint row_index_in_out_tile = m_subtile_ / 8;
+            const uint local_row_offset = row_sg_offset + m_subtile_;
+            const uint current_index_out_tile =
+                row_index_in_out_tile * (Sg_Bn / 8) + col_index_in_out_tile;
+            simdgroup_store(OutTiles[current_index_out_tile], scratch, Bn,
+                ulong2(local_col_offset, local_row_offset));
+        }
+    }
+    threadgroup float bias_tile[Bn];
+    // TODO(ibahmed): vectorize these loads an maybe unroll the loop.
+    for (uint c_local = local_tid.x; c_local < Bn; c_local += thread_count_per_tg) {
+        const uint c_global = col_tg_offset + c_local;
+        bias_tile[c_local] = (c_global < N) ? static_cast<float>(bias[c_global]) : 0.0f;
+    }
+
+    threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    const float alpha = 1.702f;
+    // TODO(ibahmed): vectorize these stores and maybe unroll the loop.
+    for (uint idx = local_tid.x; idx < Bm * Bn / 2; idx += thread_count_per_tg) {
+        const uint idx_swish = idx * 2;
+        const uint r = idx_swish / Bn;
+        const uint c_swish = idx_swish % Bn;
+
+        const uint out_row = row_tg_offset + r;
+        const uint out_col = (col_tg_offset / 2) + (c_swish / 2);
+
+        if (out_row < M && out_col < N_output) {
+            float acc_swish = scratch[idx_swish] + bias_tile[c_swish];
+            float acc_linear = scratch[idx_swish + 1] + bias_tile[c_swish + 1];
+            const float swish = metal::min(acc_swish, params.swiglu_max);
+            const float linear = metal::clamp(acc_linear, params.swiglu_min, params.swiglu_max);
+            const float swish_y = swish / (1.0f + metal::precise::exp(-alpha * swish));
+            const float swiglu_y = metal::fma(swish_y, linear, swish_y);
+            out[out_row * N_output + out_col] = swiglu_y;
+        }
+    }
+}
+
+kernel void gptoss_f32_mf4w_moe_dense_matmul(
+    constant gptoss_moe_dense_matmul_args& params [[ buffer(0) ]],
+    const device float* lhs [[ buffer(1) ]],
+    const device uint* weight_blocks [[ buffer(2) ]],
+    const device uchar* weight_scales [[ buffer(3) ]],
+    const device bfloat* __restrict__ bias [[ buffer(4) ]],
+    device float* out [[ buffer(5) ]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint3 threads_per_tg [[threads_per_threadgroup]],
+    uint sg_count_per_tg [[dispatch_simdgroups_per_threadgroup]],
+    uint3 gid [[thread_position_in_grid]],
+    uint3 tg_id [[threadgroup_position_in_grid]],
+    uint3 local_tid [[thread_position_in_threadgroup]]) 
+{
+    const uint Bm = MOE_DENSE_MATMUL_Bm;
+    const uint Bn = MOE_DENSE_MATMUL_Bn;
+    const uint Bk = MOE_DENSE_MATMUL_Bk;
+    const uint Sg_Bm = MOE_DENSE_MATMUL_Sg_Bm;
+    const uint Sg_Bn = MOE_DENSE_MATMUL_Sg_Bn;
+    assert(Bm % 8 == 0);
+    assert(Bn % 8 == 0);
+    assert(Bk % 8 == 0);
+    assert(Sg_Bm % 8 == 0);
+    assert(Sg_Bn % 8 == 0);
+    assert(Bm % Sg_Bm == 0);
+    assert(Bn % Sg_Bn == 0);
+
+    const uint K = params.k;
+    const uint N = params.n;
+    const uint M = params.expert_token_count;
+    assert((K % 32) == 0);
+    assert((K % 8) == 0);
+    assert(N % Bn == 0);
+    assert(K % Bk == 0);
+    // Get row and col tg.
+    const uint row_tg = tg_id.y;
+    const uint col_tg = tg_id.x;
+    // Get row and col local tid.
+    const uint row_tg_offset = row_tg * Bm;
+    const uint col_tg_offset = col_tg * Bn;
+    if (row_tg_offset >= M || col_tg_offset >= N) {
+        return;
+    }
+    // Move lhs and output according to the passed offset.
+    lhs += params.expert_token_offset * K;
+    out += params.expert_token_offset * N;
+
+    const uint e = params.expert_id;
+    const uint S = params.weight_blocks_expert_stride_bytes;
+    const uint S_scales = params.weight_scales_expert_stride_bytes;
+    const uint S_bias = params.bias_expert_stride_bytes;
+
+    const device char* wb0 = reinterpret_cast<const device char*>(weight_blocks);
+    const device char* sc0 = reinterpret_cast<const device char*>(weight_scales);
+    const device char* bi0 = reinterpret_cast<const device char*>(bias);
+
+    weight_blocks = reinterpret_cast<const device uint*>(wb0 + e * S);
+    weight_scales = reinterpret_cast<const device uchar*>(sc0 + e * S_scales);
+    bias = reinterpret_cast<const device bfloat*>(bi0 + e * S_bias);
+
+    const uint sg_col_count = Bn / Sg_Bn;
+    const uint row_sg = sg_id / sg_col_count;
+    const uint col_sg = sg_id % sg_col_count;
+
+    const uint row_sg_offset = row_sg * Sg_Bm;
+    const uint col_sg_offset = col_sg * Sg_Bn;
+    // Declare threadgroup blocks.
+    threadgroup float lhs_block[Bm * Bk];
+    // rhs_block will hold the scaled fp32 weights.
+    threadgroup float rhs_block[Bn * Bk];
+
+    constexpr uint temp_result_size = (Sg_Bm / 8) * (Sg_Bn / 8);
+    // Create an array of simdgroup_float8x8 to hold temp results.
+    metal::simdgroup_float8x8 OutTiles[temp_result_size];
+    for (uint i = 0; i < temp_result_size; i++) {
+        OutTiles[i] = metal::make_filled_simdgroup_matrix<float, 8, 8>(0.0);
+    }
+    // Linear thread id within TG (we launch 1-D TGs)
+    const uint lin_tid = local_tid.x;
+
+    const uint thread_count_per_tg = threads_per_tg.x * threads_per_tg.y * threads_per_tg.z;
+    // Iterate over all Bk blocks.
+    for (uint k_offset = 0; k_offset < K; k_offset += Bk) {
+        constexpr uint lhs_row_stride = Bk;
+        constexpr uint lhs_vec_cols = Bk / 4;
+        constexpr uint lhs_vec_total = Bm * lhs_vec_cols;
+
+        const uint LHS_ITERS = ceil_div(lhs_vec_total, thread_count_per_tg);
+
+        for (uint t = 0; t < LHS_ITERS; ++t) {
+            const uint i = t * thread_count_per_tg + lin_tid;
+            if (i < lhs_vec_total) {
+                const uint r = i / lhs_vec_cols;
+                const uint c4 = i % lhs_vec_cols;
+
+                const uint gr = row_tg_offset + r;
+                const uint gc4 = (k_offset / 4) + c4;
+
+                threadgroup float4* dst4 =
+                    reinterpret_cast<threadgroup float4*>(lhs_block + r * lhs_row_stride + (c4 << 2));
+                if (gr < M) {
+                    const device float4* src4 =
+                        reinterpret_cast<const device float4*>(lhs + gr * K + (gc4 << 2));
+
+                    *dst4 = *src4;
+                } else {
+                    *dst4 = float4(0.0);
+                }
+            }
+        }
+
+        // Load weights with vector loads.
+        constexpr uint rhs_row_stride = Bk;
+        constexpr uint weights_per_elem = 8;
+        constexpr uint rhs_loads_per_col = Bk / weights_per_elem;
+        constexpr uint rhs_loads_total = Bn * rhs_loads_per_col;
+        const uint RHS_ITERS = ceil_div(rhs_loads_total, thread_count_per_tg);
+        // #pragma clang loop unroll(full)
+        for (uint t = 0; t < RHS_ITERS; ++t) {
+            const uint i = t * thread_count_per_tg + lin_tid;
+            if (i < rhs_loads_total) {
+                const uint r = i / rhs_loads_per_col;
+                const uint c = i % rhs_loads_per_col;
+
+                const uint gr = col_tg_offset + r;
+                const uint gc = (k_offset / weights_per_elem) + c;
+                const uint gc_scale = (k_offset / 32) + (c >> 2);
+
+                const uint wblock = weight_blocks[gr * (K / weights_per_elem) + gc];
+                const float scale =
+                    as_type<float>(static_cast<uint>(weight_scales[gr * (K / 32) + gc_scale]) << 23);
+
+                uint wblock0246 = (wblock + wblock);
+                uint wblock1357 = (wblock >> 3);
+                wblock0246 &= 0x1E1E1E1Eu;
+                wblock1357 &= 0x1E1E1E1Eu;
+
+                wblock0246 += 0x70707070u;
+                wblock1357 += 0x70707070u;
+                wblock0246 &= 0x8E8E8E8Eu;
+                wblock1357 &= 0x8E8E8E8Eu;
+
+                uint wblock26 = (wblock0246) & 0xFF00FF00u;
+                uint wblock04 = ((wblock0246 << 8)) & 0xFF00FF00u;
+                uint wblock37 = (wblock1357) & 0xFF00FF00u;
+                uint wblock15 = ((wblock1357 << 8)) & 0xFF00FF00u;
+
+                half4 wblock0426 = as_type<half4>(uint2(wblock04, wblock26));
+                half4 wblock1537 = as_type<half4>(uint2(wblock15, wblock37));
+
+                const float w0 = float(wblock0426.x) * scale;
+                const float w1 = float(wblock1537.x) * scale;
+                const float w2 = float(wblock0426.z) * scale;
+                const float w3 = float(wblock1537.z) * scale;
+                const float w4 = float(wblock0426.y) * scale;
+                const float w5 = float(wblock1537.y) * scale;
+                const float w6 = float(wblock0426.w) * scale;
+                const float w7 = float(wblock1537.w) * scale;
+                const uint rhs_offset = r * rhs_row_stride + c * 8;
+                rhs_block[rhs_offset] = w0;
+                rhs_block[rhs_offset + 1] = w1;
+                rhs_block[rhs_offset + 2] = w2;
+                rhs_block[rhs_offset + 3] = w3;
+                rhs_block[rhs_offset + 4] = w4;
+                rhs_block[rhs_offset + 5] = w5;
+                rhs_block[rhs_offset + 6] = w6;
+                rhs_block[rhs_offset + 7] = w7;
+            }
+        }
+        threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+#pragma clang loop unroll(full)
+        for (uint k = 0; k < Bk; k += 8) {
+#pragma clang loop unroll(full)
+            for (uint m_subtile_ = 0; m_subtile_ < Sg_Bm; m_subtile_ += 8) {
+                const uint row_index_in_out_tile = m_subtile_ / 8;
+                metal::simdgroup_float8x8 lhs_frag;
+
+                simdgroup_load(lhs_frag, lhs_block, Bk, ulong2(k, m_subtile_ + row_sg_offset));
+#pragma clang loop unroll(full)
+                for (uint n_subtile_ = 0; n_subtile_ < Sg_Bn; n_subtile_ += 8) {
+                    const uint col_index_in_out_tile = n_subtile_ / 8;
+                    const uint current_index_out_tile =
+                        row_index_in_out_tile * (Sg_Bn / 8) + col_index_in_out_tile;
+                    metal::simdgroup_float8x8 rhs_frag;
+                    simdgroup_load(rhs_frag, rhs_block, Bk, ulong2(k, n_subtile_ + col_sg_offset), true);
+                    simdgroup_multiply_accumulate(OutTiles[current_index_out_tile], lhs_frag, rhs_frag,
+                        OutTiles[current_index_out_tile]);
+                }
+            }
+        }
+        threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    }
+
+    // Epilogue.
+    threadgroup float scratch[Bm * Bn];
+#pragma clang loop unroll(full)
+    for (uint n_subtile_ = 0; n_subtile_ < Sg_Bn; n_subtile_ += 8) {
+        const uint col_index_in_out_tile = n_subtile_ / 8;
+        const uint local_col_offset = col_sg_offset + n_subtile_;
+#pragma clang loop unroll(full)
+        for (uint m_subtile_ = 0; m_subtile_ < Sg_Bm; m_subtile_ += 8) {
+            const uint row_index_in_out_tile = m_subtile_ / 8;
+            const uint local_row_offset = row_sg_offset + m_subtile_;
+            const uint current_index_out_tile =
+                row_index_in_out_tile * (Sg_Bn / 8) + col_index_in_out_tile;
+            simdgroup_store(OutTiles[current_index_out_tile], scratch, Bn,
+                ulong2(local_col_offset, local_row_offset));
+        }
+    }
+    threadgroup float bias_tile[Bn];
+    for (uint c_local = local_tid.x; c_local < Bn; c_local += thread_count_per_tg) {
+        const uint c_global = col_tg_offset + c_local;
+        bias_tile[c_local] = (c_global < N) ? static_cast<float>(bias[c_global]) : 0.0f;
+    }
+
+    threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    for (uint idx = local_tid.x; idx < Bm * Bn; idx += thread_count_per_tg) {
+        const uint r = idx / Bn;
+        const uint c = idx % Bn;
+
+        const uint out_row = row_tg_offset + r;
+        const uint out_col = col_tg_offset + c;
+
+        if (out_row < M && out_col < N) {
+            float acc = scratch[idx] + bias_tile[c];
+            out[out_row * N + out_col] = acc;
+        }
     }
 }

--- a/gpt_oss/metal/source/scatter.metal
+++ b/gpt_oss/metal/source/scatter.metal
@@ -1,0 +1,65 @@
+#include <internal/kernel-args.h>
+#include <metal_integer>
+#include <metal_math>
+#include <metal_stdlib>
+
+// TODO(ibrahim): This is not optimal as each thread only scatters a single float4. To amortize the
+// cost of reading the expert id and offset for a token, we should let each thread scatter several
+// float4s.
+kernel void gptoss_f32_scatter_e4(
+    constant gptoss_scatter_args& args [[ buffer(0) ]],
+    const device float* in [[ buffer(1) ]],
+    const device gptoss_expert_prediction* __restrict__ expert_predictions [[ buffer(2) ]],
+    const device uint* __restrict__ expert_offsets [[ buffer(3) ]],
+    const device uint* __restrict__ intra_expert_offsets [[ buffer(4) ]],
+    device float* out [[ buffer(5) ]],
+    uint3 gid [[thread_position_in_grid]]) 
+{
+    const uint total_tokens = args.tokens;
+    const uint active_experts_per_token = args.active_experts_per_token;
+    const uint embedding_dim = args.token_stride;
+    assert(embedding_dim % 4 == 0);
+    // Hard coded to top4 for now.
+    assert(active_experts_per_token == 4);
+    const uint row_in = gid.y;
+    if (row_in >= total_tokens) {
+        return;
+    }
+    // Consecutive threads in a tg read consecutive columns of the input.
+    const uint col_in_vec4 = gid.x;
+    const uint col_in = col_in_vec4 * 4;
+    if (col_in >= embedding_dim) {
+        return;
+    }
+    // Pointer to the piece of the input that we will copy to the top4 experts.
+    const device float4* src4 =
+        reinterpret_cast<const device float4*>(in + row_in * embedding_dim + col_in);
+
+    // Get the 4 destinations -- 4 experts.
+    const uint base = row_in * active_experts_per_token;
+    const uint expert0_id = expert_predictions[base].expert_id;
+    const uint expert1_id = expert_predictions[base + 1].expert_id;
+    const uint expert2_id = expert_predictions[base + 2].expert_id;
+    const uint expert3_id = expert_predictions[base + 3].expert_id;
+    const uint expert0_offset = expert_offsets[expert0_id];
+    const uint expert1_offset = expert_offsets[expert1_id];
+    const uint expert2_offset = expert_offsets[expert2_id];
+    const uint expert3_offset = expert_offsets[expert3_id];
+    const uint expert0_intra_expert_offset = intra_expert_offsets[base];
+    const uint expert1_intra_expert_offset = intra_expert_offsets[base + 1];
+    const uint expert2_intra_expert_offset = intra_expert_offsets[base + 2];
+    const uint expert3_intra_expert_offset = intra_expert_offsets[base + 3];
+    device float4* dst4_0 = reinterpret_cast<device float4*>(
+        out + (expert0_offset + expert0_intra_expert_offset) * embedding_dim + col_in);
+    device float4* dst4_1 = reinterpret_cast<device float4*>(
+        out + (expert1_offset + expert1_intra_expert_offset) * embedding_dim + col_in);
+    device float4* dst4_2 = reinterpret_cast<device float4*>(
+        out + (expert2_offset + expert2_intra_expert_offset) * embedding_dim + col_in);
+    device float4* dst4_3 = reinterpret_cast<device float4*>(
+        out + (expert3_offset + expert3_intra_expert_offset) * embedding_dim + col_in);
+    const float4 data = *src4;
+    *dst4_0 = data;
+    *dst4_1 = data;
+    *dst4_2 = data;
+    *dst4_3 = data;
+}


### PR DESCRIPTION
Adding scatter and gather kernel to map token to experts and perform the inverse op.
Also added moe matmul kernels. These kernels speed up prefill.
These kernels are not used by the metal backend yet. In the next PR, they weill be