### PR TITLE
Add a Java port of gpt-oss in awesome-gpt-oss.md

### DIFF
--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -36,6 +36,8 @@ This is a list of guides and resources to help you get started with the gpt-oss 
 - llama.cpp
   - [Running gpt-oss with llama.cpp](https://github.com/ggml-org/llama.cpp/discussions/15396)
   - [Running gpt-oss with Unsloth GGUFs](https://docs.unsloth.ai/new/gpt-oss-how-to-run-and-fine-tune#run-gpt-oss-20b)
+- Notable ports
+  - [amzn/gpt-oss.java](https://github.com/amzn/gpt-oss.java)
 
 ### Server
 


### PR DESCRIPTION
A pure Java implementation gpt-oss inference in ~1000 lines of code optimized for CPU execution.

Inspired by [llama.cpp](https://github.com/ggml-org/llama.cpp), [llama2.c](https://github.com/karpathy/llama2.c), this repo ports the gpt-oss PyTorch [model.py](https://github.com/openai/gpt-oss/blob/main/gpt_oss/torch/model.py) to efficient Java code, emphasizing minimalism, simplicity, and educational purpose.

See more https://github.com/amzn/gpt-oss.java