### PR TITLE
fix: remove duplicated variable causing Metal build failure

### DIFF
--- a/gpt_oss/metal/python/context.c
+++ b/gpt_oss/metal/python/context.c
@@ -11,7 +11,6 @@ static int PyGPTOSSContext_init(PyGPTOSSContext* self, PyObject* args, PyObject*
     Py_ssize_t context_length = 0; // Default to 0 if None
     Py_ssize_t max_batch_tokens = 0; // Default to 0 if None
 
-    PyObject* model = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!|$ii", kwlist,
                                      &PyGPTOSSModel_Type, &model,
                                      &context_length, &max_batch_tokens))


### PR DESCRIPTION
This PR fixes a compilation error that occurs when building with Metal support on macOS.

When running:

```
git clone https://github.com/openai/gpt-oss/
GPTOSS_BUILD_METAL=1 pip install -e ".[metal]"
```


the build fails with the following error
```
/Users/xx/Desktop/program/gpt-oss/gpt_oss/metal/python/context.c:14:15: error: redefinition of 'model'
   14 |     PyObject* model = NULL;
      |               ^
/Users/xx/Desktop/program/gpt-oss/gpt_oss/metal/python/context.c:10:15: note: previous definition is here
   10 |     PyObject* model = NULL;
```

so remove duplicated variable