### PR TITLE
Eliding copying the KV after RoPE to the KV cache during prefill

### DIFF
--- a/gpt_oss/metal/source/include/internal/kernel-args.h
+++ b/gpt_oss/metal/source/include/internal/kernel-args.h
@@ -104,6 +104,15 @@ struct gptoss_dense_matmul_args {
     uint32_t k;
 };
 
+// Specialize qkv matmul args as it writes kv directly to the KV cache buffer.
+struct gptoss_dense_matmul_qkv_args {
+    uint32_t m;
+    uint32_t n;
+    uint32_t k;
+    uint32_t max_tokens;
+    uint32_t token_offset;
+};
+
 struct gptoss_scatter_args {
     uint32_t tokens;
     uint32_t active_experts_per_token;
@@ -166,6 +175,7 @@ struct gptoss_moe_matmul_args {
 struct gptoss_rope_args {
     uint32_t token_stride;
     uint32_t token_offset;
+    uint32_t max_tokens;
     float freq_scale;
     float interpolation_scale;
     float yarn_offset;

--- a/gpt_oss/metal/source/include/internal/metal-kernels.h
+++ b/gpt_oss/metal/source/include/internal/metal-kernels.h
@@ -171,11 +171,15 @@ gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_matmul_qkv(
     size_t bias_offset,
     const struct gptoss_metal_buffer* output_buffer,
     size_t output_offset,
+    const struct gptoss_metal_buffer* kv_buffer,
+    size_t kv_offset,
     const struct gptoss_metal_buffer* control_buffer,
     size_t control_offset,
     uint32_t num_tokens,
     uint32_t num_cols,
-    uint32_t num_rows);
+    uint32_t num_rows,
+    uint32_t max_tokens,
+    uint32_t token_offset);
 
 enum gptoss_status
 gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_matmul_attn_output(
@@ -287,6 +291,8 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_rope(
     size_t threadgroup_size,
     const struct gptoss_metal_buffer* activations_buffer,
     size_t activations_offset,
+    const struct gptoss_metal_buffer* kv_buffer,
+    size_t kv_offset,
     const struct gptoss_metal_buffer* control_buffer,
     size_t control_offset,
     float rope_base,
@@ -298,6 +304,7 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_rope(
     uint32_t num_q_heads,
     uint32_t num_kv_heads,
     uint32_t attn_head_dim,
+    uint32_t max_tokens,
     uint32_t token_offset);
 
 enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_accumulate(

--- a/gpt_oss/metal/source/matmul.metal
+++ b/gpt_oss/metal/source/matmul.metal
@@ -358,12 +358,13 @@ inline void _gptoss_f32_bf16w_dense_matmul_impl(
 }
 
 kernel void gptoss_f32_bf16w_dense_matmul_qkv(
-    constant gptoss_dense_matmul_args& args [[buffer(0)]],
+    constant gptoss_dense_matmul_qkv_args& args [[buffer(0)]],
     const device float* lhs [[buffer(1)]],
     const device bfloat* rhs [[buffer(2)]],
     const device bfloat* __restrict__ bias [[buffer(3)]],
     device float* out [[buffer(4)]],
-    const device gptoss_control* control [[buffer(5)]],
+    device float* kv [[buffer(5)]],
+    const device gptoss_control* control [[buffer(6)]],
     uint sg_id [[simdgroup_index_in_threadgroup]],
     uint sg_count_per_tg [[dispatch_simdgroups_per_threadgroup]],
     uint3 gid [[thread_position_in_grid]],
@@ -372,10 +373,128 @@ kernel void gptoss_f32_bf16w_dense_matmul_qkv(
     uint3 threadgroup_size [[threads_per_threadgroup]]) {
     threadgroup float scratch[QKV_Bm * QKV_Bn];
     threadgroup float bias_tile[QKV_Bn];
-    _gptoss_f32_bf16w_dense_matmul_impl<QKV_Bm, QKV_Bn, QKV_Bk, QKV_Sg_Bm,
-                                        QKV_Sg_Bn>(
-        args, lhs, rhs, bias, out, control, scratch, bias_tile, sg_id, sg_count_per_tg,
-        gid, tg_id, local_tid, threadgroup_size);
+    if (control->abort != 0) {
+        return;
+    }
+
+    // The kernel assumes that QKV_Bm, QKV_Bn, QKV_Bk, QKV_Sg_Bm, QKV_Sg_Bn are divisible by 8.
+    const uint M = args.m;
+    const uint K = args.k;
+    const uint N = args.n;
+    const uint Bm = QKV_Bm;
+    const uint Bn = QKV_Bn;
+    const uint Bk = QKV_Bk;
+    const uint Sg_Bm = QKV_Sg_Bm;
+    const uint Sg_Bn = QKV_Sg_Bn;
+    static_assert((Bm % 8u) == 0u, "Bm must be a multiple of 8");
+    static_assert((Bn % 8u) == 0u, "Bn must be a multiple of 8");
+    static_assert((Bk % 8u) == 0u, "Bk must be a multiple of 8");
+    static_assert((Sg_Bm % 8u) == 0u, "Bk must be a multiple of 8");
+    static_assert((Sg_Bn % 8u) == 0u, "Bk must be a multiple of 8");
+    static_assert((Bn % Sg_Bn) == 0u, "Bn must be a multiple of Sg_Bn");
+    static_assert((Bm % Sg_Bm) == 0u, "Bm must be a multiple of Sg_Bm");
+
+    // Get row and col tg.
+    const uint row_tg = tg_id.y;
+    const uint col_tg = tg_id.x;
+    // Get row and col local tid.
+    const uint row_tg_offset = row_tg * Bm;
+    const uint col_tg_offset = col_tg * Bn;
+
+    const uint sg_col_count = Bn / Sg_Bn;
+    const uint row_sg = sg_id / sg_col_count;
+    const uint col_sg = sg_id % sg_col_count;
+
+    const uint row_sg_offset = row_sg * Sg_Bm;
+    const uint col_sg_offset = col_sg * Sg_Bn;
+    constexpr uint temp_result_size = (Sg_Bm / 8) * (Sg_Bn / 8);
+    // Create an array of simdgroup_float8x8 to hold temp results.
+    metal::simdgroup_float8x8 OutTiles[temp_result_size];
+#pragma clang loop unroll(full)
+    for (uint i = 0; i < temp_result_size; i++) {
+        OutTiles[i] = metal::make_filled_simdgroup_matrix<float, 8, 8>(
+            static_cast<float>(0.0));
+    }
+
+    for (uint k_offset = 0; k_offset < K; k_offset += Bk) {
+#pragma clang loop unroll(full)
+        for (uint k = 0; k < Bk; k += 8) {
+#pragma clang loop unroll(full)
+            for (uint m_subtile_ = 0; m_subtile_ < Sg_Bm; m_subtile_ += 8) {
+                const uint row_index_in_out_tile = m_subtile_ / 8;
+                metal::simdgroup_float8x8 LHStile;
+                const uint k_id = k + k_offset;
+                const uint row_offset = row_tg_offset + row_sg_offset + m_subtile_;
+                metal::simdgroup_load(LHStile, lhs, K, ulong2(k_id, row_offset));
+                metal::simdgroup_bfloat8x8 RHStile;
+#pragma clang loop unroll(full)
+                for (uint n_subtile_ = 0; n_subtile_ < Sg_Bn; n_subtile_ += 8) {
+                    const uint col_index_in_out_tile = n_subtile_ / 8;
+                    const uint current_index_out_tile =
+                        row_index_in_out_tile * (Sg_Bn / 8) + col_index_in_out_tile;
+                    const uint col_offset = col_tg_offset + col_sg_offset + n_subtile_;
+                    simdgroup_load(RHStile, rhs, K, ulong2(k_id, col_offset), /*transpose=*/true);
+                    simdgroup_multiply_accumulate(OutTiles[current_index_out_tile],
+                                                  LHStile, RHStile,
+                                                  OutTiles[current_index_out_tile]);
+                }
+            }
+        }
+    }
+    // Epilogue.
+#pragma clang loop unroll(full)
+    for (uint n_subtile_ = 0; n_subtile_ < Sg_Bn; n_subtile_ += 8) {
+        const uint col_index_in_out_tile = n_subtile_ / 8;
+        const uint local_col_offset = col_sg_offset + n_subtile_;
+#pragma clang loop unroll(full)
+        for (uint m_subtile_ = 0; m_subtile_ < Sg_Bm; m_subtile_ += 8) {
+            const uint row_index_in_out_tile = m_subtile_ / 8;
+            const uint local_row_offset = row_sg_offset + m_subtile_;
+            const uint current_index_out_tile =
+                row_index_in_out_tile * (Sg_Bn / 8) + col_index_in_out_tile;
+            simdgroup_store(OutTiles[current_index_out_tile], scratch, Bn,
+                            ulong2(local_col_offset, local_row_offset));
+        }
+    }
+    // TODO(ibahmed): vectorize these loads an maybe unroll the loop.
+    const uint thread_count_per_tg =
+        threadgroup_size.x * threadgroup_size.y * threadgroup_size.z;
+    for (uint c_local = local_tid.x; c_local < Bn;
+         c_local += thread_count_per_tg) {
+        const uint c_global = col_tg_offset + c_local;
+        bias_tile[c_local] =
+            (c_global < N) ? static_cast<float>(bias[c_global]) : 0.0f;
+    }
+
+    metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+    const uint q_heads = 64;
+    const uint kv_heads = 8;
+    const uint head_dim = 64;
+    const uint q_cols = q_heads * head_dim;
+    const uint k_cols = kv_heads * head_dim;
+
+    // TODO(ibahmed): vectorize these stores and maybe unroll the loop.
+    for (uint idx = local_tid.x; idx < Bm * Bn; idx += thread_count_per_tg) {
+        const uint r = idx / Bn;
+        const uint c = idx % Bn;
+
+        const uint out_row = row_tg_offset + r;
+        const uint out_col = col_tg_offset + c;
+
+        if (out_row < M && out_col < N) {
+            float acc = scratch[idx] + bias_tile[c];
+            if ((out_col < q_cols + k_cols)) {
+                out[out_row * N + out_col] = acc;
+            } else {
+                // Write v into kv cache.
+                const uint v_col = out_col - q_cols - k_cols;
+                const uint v_head = v_col / head_dim;
+                const uint dim_idx = v_col % head_dim;
+                const uint token_idx = args.token_offset + out_row;
+                kv[(v_head * args.max_tokens + token_idx) * 2 * head_dim + head_dim + dim_idx] = acc;
+            }
+        }
+    }
 }
 
 kernel void gptoss_f32_bf16w_dense_matmul_attn_output(

--- a/gpt_oss/metal/source/metal-kernels.c
+++ b/gpt_oss/metal/source/metal-kernels.c
@@ -534,11 +534,6 @@ enum gptoss_status _gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_ma
                          num_rows);
         return gptoss_status_invalid_argument;
     }
-    if (num_tokens % 8 != 0) {
-        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: number of tokens (%" PRIu32 ") is not divisible by 8",
-                         num_tokens);
-        return gptoss_status_invalid_argument;
-    }
 
     const struct gptoss_dense_matmul_args args = {
         .m = num_tokens,
@@ -568,11 +563,6 @@ enum gptoss_status _gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_ma
                          total_threadgroup_size, f32_bf16w_dense_matmul_fn->max_threadgroup_threads);
         return gptoss_status_invalid_argument;
     }
-    if (m % Bm != 0) {
-        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: m (%" PRIu32 ") is not divisible by Bm (%" PRIu32 ")",
-                         m, Bm);
-        return gptoss_status_invalid_argument;
-    }
     if (n % Bn != 0) {
         GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: n (%" PRIu32 ") is not divisible by Bn (%" PRIu32 ")",
                          n, Bn);
@@ -584,7 +574,7 @@ enum gptoss_status _gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_ma
         return gptoss_status_invalid_argument;
     }
     const size_t grid_x = n / Bn;
-    const size_t grid_y = m / Bm;
+    const size_t grid_y = math_ceil_div(m, Bm);
     const size_t grid_z = 1;
 
     return gptoss_metal_command_buffer_encode_launch_kernel(
@@ -610,17 +600,86 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_mat
     size_t bias_offset,
     const struct gptoss_metal_buffer* output_buffer,
     size_t output_offset,
+    const struct gptoss_metal_buffer* kv_buffer,
+    size_t kv_offset,
     const struct gptoss_metal_buffer* control_buffer,
     size_t control_offset,
     uint32_t num_tokens,
     uint32_t num_cols,
-    uint32_t num_rows)
+    uint32_t num_rows,
+    uint32_t max_tokens,
+    uint32_t token_offset)
 {
-    return _gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_matmul_impl(
-        command_buffer, f32_bf16w_dense_matmul_fn, input_buffer, input_offset, 
-        weight_buffer, weight_offset, bias_buffer, bias_offset, output_buffer,
-        output_offset, control_buffer, control_offset, num_tokens, num_cols, num_rows, QKV_Bm, QKV_Bn, QKV_Bk,
-        QKV_Sg_Bm, QKV_Sg_Bn);
+    if (command_buffer->object == NULL || f32_bf16w_dense_matmul_fn->pipeline_state_object == NULL) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: invalid command buffer or pipeline state object");
+        return gptoss_status_invalid_state;
+    }
+
+    if (num_cols % 8 != 0) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: number of columns (%" PRIu32 ") is not divisible by 8",
+                         num_cols);
+        return gptoss_status_invalid_argument;
+    }
+    if (num_rows % 8 != 0) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: number of rows (%" PRIu32 ") is not divisible by 8",
+                         num_rows);
+        return gptoss_status_invalid_argument;
+    }
+
+    const struct gptoss_dense_matmul_qkv_args args = {
+        .m = num_tokens,
+        .n = num_rows,
+        .k = num_cols,
+        .max_tokens = max_tokens,
+        .token_offset = token_offset,
+    };
+    const size_t threads_per_simdgroup = f32_bf16w_dense_matmul_fn->simdgroup_threads;
+    const uint32_t m = args.m;
+    const uint32_t n = args.n;
+    const uint32_t k = args.k;
+    if (QKV_Bm % QKV_Sg_Bm != 0) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: Bm (%" PRIu32 ") is not divisible by Sg_Bm (%" PRIu32 ")",
+                         QKV_Bm, QKV_Sg_Bm);
+        return gptoss_status_invalid_argument;
+    }
+    if (QKV_Bn % QKV_Sg_Bn != 0) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: Bn (%" PRIu32 ") is not divisible by Sg_Bn (%" PRIu32 ")",
+                         QKV_Bn, QKV_Sg_Bn);
+        return gptoss_status_invalid_argument;
+    }
+    const size_t threadgroup_size_x = (QKV_Bm / QKV_Sg_Bm) * (QKV_Bn / QKV_Sg_Bn) * threads_per_simdgroup;
+    const size_t threadgroup_size_y = 1;
+    const size_t threadgroup_size_z = 1;
+    const size_t total_threadgroup_size = threadgroup_size_x * threadgroup_size_y * threadgroup_size_z;
+    if (total_threadgroup_size > f32_bf16w_dense_matmul_fn->max_threadgroup_threads) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: total threadgroup size (%zu) exceeds supported maximum (%zu)",
+                         total_threadgroup_size, f32_bf16w_dense_matmul_fn->max_threadgroup_threads);
+        return gptoss_status_invalid_argument;
+    }
+    if (n % QKV_Bn != 0) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: n (%" PRIu32 ") is not divisible by Bn (%" PRIu32 ")",
+                         n, QKV_Bn);
+        return gptoss_status_invalid_argument;
+    }
+    if (k % QKV_Bk != 0) {
+        GPTOSS_LOG_ERROR("failed to encode f32_bf16w_dense_matmul kernel launch: k (%" PRIu32 ") is not divisible by Bk (%" PRIu32 ")",
+                         k, QKV_Bk);
+        return gptoss_status_invalid_argument;
+    }
+    const size_t grid_x = n / QKV_Bn;
+    const size_t grid_y = math_ceil_div(m, QKV_Bm);
+    const size_t grid_z = 1;
+
+    return gptoss_metal_command_buffer_encode_launch_kernel(
+        command_buffer, f32_bf16w_dense_matmul_fn,
+        threadgroup_size_x, threadgroup_size_y, threadgroup_size_z,
+        grid_x, grid_y, grid_z,
+        sizeof(args), &args,
+        6,
+        (const struct gptoss_metal_buffer *[]){input_buffer, weight_buffer, bias_buffer, output_buffer, kv_buffer, control_buffer},
+        (const size_t[]){input_offset, weight_offset, bias_offset, output_offset, kv_offset, control_offset},
+        /*threadgroup_buffer_size=*/0);
+    return gptoss_status_success;
 }
 
 enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_bf16w_dense_matmul_attn_output(
@@ -886,6 +945,8 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_rope(
     size_t threadgroup_size,
     const struct gptoss_metal_buffer* activations_buffer,
     size_t activations_offset,
+    const struct gptoss_metal_buffer* kv_buffer,
+    size_t kv_offset,
     const struct gptoss_metal_buffer* control_buffer,
     size_t control_offset,
     float rope_base,
@@ -897,6 +958,7 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_rope(
     uint32_t num_q_heads,
     uint32_t num_kv_heads,
     uint32_t attn_head_dim,
+    uint32_t max_tokens,
     uint32_t token_offset)
 {
     if (command_buffer->object == NULL || f32_rope_fn->pipeline_state_object == NULL) {
@@ -918,6 +980,7 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_rope(
     const struct gptoss_rope_args args = {
         .token_stride = (num_q_heads + 2 * num_kv_heads) * (attn_head_dim / 2),
         .token_offset = token_offset,
+        .max_tokens = max_tokens,
         .freq_scale = -logf(rope_base) / (float) (int32_t) (attn_head_dim / 2),
         .interpolation_scale = interpolation_scale,
         .yarn_offset = yarn_offset,
@@ -930,9 +993,9 @@ enum gptoss_status gptoss_metal_command_buffer_encode_launch_f32_rope(
         threadgroup_size, 1, 1,
         num_qk_heads / num_simdgroups, num_tokens, 1,
         sizeof(args), &args,
-        2,
-        (const struct gptoss_metal_buffer *[]) {activations_buffer, control_buffer},
-        (const size_t[]) {activations_offset, control_offset},
+        3,
+        (const struct gptoss_metal_buffer *[]) {activations_buffer, kv_buffer, control_buffer},
+        (const size_t[]) {activations_offset, kv_offset, control_offset},
         /*threadgroup_buffer_size=*/0);
 }
 

--- a/gpt_oss/metal/source/rope.metal
+++ b/gpt_oss/metal/source/rope.metal
@@ -13,7 +13,8 @@
 kernel void gptoss_f32_rope(
     constant gptoss_rope_args& args [[ buffer(0) ]],
     device float2* activations [[ buffer(1) ]],
-    const device gptoss_control* control [[ buffer(2) ]],
+    device float2* kv [[ buffer(2) ]],
+    const device gptoss_control* control [[ buffer(3) ]],
     uint2 gid [[thread_position_in_grid]])
 {
     const uint num_head_dims = 64;
@@ -40,4 +41,18 @@ kernel void gptoss_f32_rope(
     const float output_re = input_vals.x * cosphi - input_vals.y * sinphi;
     const float output_im = input_vals.x * sinphi + input_vals.y * cosphi;
     *activations = (float2) { output_re, output_im };
+
+    const uint head_dim = 64;
+    const uint num_q_heads = 64;
+    const uint num_kv_heads = 8;
+    const uint head_idx = gid.x / (head_dim / 2);
+    float2 vals = (float2) { output_re, output_im };
+    if ((head_idx < num_q_heads)) {
+        *activations = vals;
+    } else if (head_idx < num_q_heads + num_kv_heads) {
+        // Write k and v directly to the kv cache.
+        const uint kv_head_idx = head_idx - num_q_heads;
+        const uint dim_pair_idx = gid.x % (head_dim / 2);
+        kv[(kv_head_idx * args.max_tokens + token_idx) * head_dim + dim_pair_idx] = vals;
+    }
 }


### PR DESCRIPTION
This PR improves prefill performance by removing a copy that happened after the RoPE kernel. Originally, we copied KV into the KV cache buffer after RoPE and QKV. With this PR, during QKV matmul we write V directly to KV cache, and RoPE kernel also directly writes K to KV cache.

gptoss-20b TTFT for a 1k context running on my M4 max was 1161 ms, after this PR it is 960 ms --> 20% perf improvement.