### PR TITLE
refactor: remove unused base_url and session params from replace_images

### DIFF
--- a/gpt_oss/tools/simple_browser/page_contents.py
+++ b/gpt_oss/tools/simple_browser/page_contents.py
@@ -235,8 +235,6 @@ def replace_node_with_text(node: lxml.html.HtmlElement, text: str) -> None:
 
 def replace_images(
     root: lxml.html.HtmlElement,
-    base_url: str,
-    session: aiohttp.ClientSession | None,
 ) -> None:
     """Finds all image tags and replaces them with numbered placeholders (includes alt/title if available)."""
     cnt = 0
@@ -274,11 +272,7 @@ def process_html(
         final_title = ""
 
     urls = _clean_links(root, url)
-    replace_images(
-        root=root,
-        base_url=url,
-        session=session,
-    )
+    replace_images(root=root)
     _remove_math(root)
     clean_html = lxml.etree.tostring(root, encoding="UTF-8").decode()
     text = html_to_text(clean_html)


### PR DESCRIPTION
This PR removes unused base_url and session parameters from the replace_images() function in page_contents.py. These parameters were passed but never used in the function body, creating unnecessary complexity and potential confusion for future maintainers.
With this PR, the function signature is simplified from replace_images(root, base_url, session) to replace_images(root), and the single call site is updated accordingly. All 25 existing tests pass, confirming no functional changes