### PR TITLE
fix gpt_oss/triton/attention.py bug

### DIFF
--- a/gpt_oss/triton/attention.py
+++ b/gpt_oss/triton/attention.py
@@ -59,9 +59,9 @@ def _attn_fwd(
     q = Q.load([off_z, off_h, start_m * BLOCK_M, 0]).reshape([BLOCK_M, HEAD_DIM])
 
     if BANDWIDTH:
-        lo, hi = tl.maximum(start_q, start_q + start_m * BLOCK_M - BANDWIDTH), start_q + (start_m + 1) * BLOCK_M
+        lo, hi = tl.maximum(0, start_q + start_m * BLOCK_M - BANDWIDTH), start_q + (start_m + 1) * BLOCK_M
     else:
-        lo, hi = start_q, start_q + (start_m + 1) * BLOCK_M
+        lo, hi = 0, start_q + (start_m + 1) * BLOCK_M
     hi = tl.minimum(hi, N_KV_CTX)
 
     for start_n in range(lo, hi, BLOCK_N):
@@ -182,7 +182,6 @@ def attention_ref(
     pos_keys = torch.arange(num_keys, device=query.device)
     pos_queries = torch.arange(num_queries, device=query.device) + start_q
     mask = pos_keys[None, :] > pos_queries[:, None]
-    mask = mask | (pos_keys[None, :] < start_q)
     mask = mask.float().masked_fill(mask, float("-inf"))
 
     if sliding_window:
@@ -213,7 +212,7 @@ def attention_ref(
 @pytest.mark.parametrize("head_dim", [64])
 @pytest.mark.parametrize("sm_scale", [0.125])
 @pytest.mark.parametrize("sliding_window", [None, 128])
-@pytest.mark.parametrize("start_q", [0, 64])
+@pytest.mark.parametrize("start_q", [0, 5])
 def test_eq(batch_size, num_queries, num_keys, num_key_value_heads, num_key_value_groups, head_dim, sm_scale, sliding_window, start_q):
     if num_queries > num_keys:
         pytest.skip("too many queries")


### PR DESCRIPTION
When using pytest to run `gpt_oss/triton/attention.py `, meet failures
```
FAILED attention_sink.py::test_eq[5-None-0.125-64-8-8-128-1-1] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-None-0.125-64-8-8-128-1-2] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-None-0.125-64-8-8-128-128-1] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-None-0.125-64-8-8-128-128-2] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-None-0.125-64-8-8-32-1-1] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-None-0.125-64-8-8-32-1-2] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-128-0.125-64-8-8-128-1-1] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-128-0.125-64-8-8-128-1-2] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-128-0.125-64-8-8-128-128-1] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-128-0.125-64-8-8-128-128-2] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-128-0.125-64-8-8-32-1-1] - AssertionError: Tensor-likes are not close!
FAILED attention_sink.py::test_eq[5-128-0.125-64-8-8-32-1-2] - AssertionError: Tensor-likes are not close!
```
This MR fix those failures.
There are minor fixes:
1. Use `hi = tl.minimum(hi, N_KV_CTX)` avoid cross-border access of K.
2. The kernel implementation does not match the reference implementation, update kernel implementaion.

After those fixes, we can pass all the tests in `gpt_oss/triton/attention.py `

