### PR TITLE
Add user-agent to headers for tracking

### DIFF
--- a/gpt_oss/tools/simple_browser/backend.py
+++ b/gpt_oss/tools/simple_browser/backend.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import os
 from abc import abstractmethod
+from importlib.metadata import version
 from typing import Callable, ParamSpec, TypeVar
 from urllib.parse import quote
 
@@ -33,6 +34,11 @@ logger = logging.getLogger(__name__)
 
 
 VIEW_SOURCE_PREFIX = "view-source:"
+
+try:
+    _GPT_OSS_VERSION = version("gpt-oss")
+except Exception:
+    _GPT_OSS_VERSION = "0.0.8"  # fallback version
 
 
 class BackendError(Exception):
@@ -89,7 +95,10 @@ class Backend:
         pass
 
     async def _post(self, session: ClientSession, endpoint: str, payload: dict) -> dict:
-        headers = {"x-api-key": self._get_api_key()}
+        headers = {
+            "x-api-key": self._get_api_key(),
+            "user-agent": f"gpt-oss/{_GPT_OSS_VERSION}",
+        }
         async with session.post(f"{self.BASE_URL}{endpoint}", json=payload, headers=headers) as resp:
             if resp.status != 200:
                 raise BackendError(
@@ -98,7 +107,10 @@ class Backend:
             return await resp.json()
 
     async def _get(self, session: ClientSession, endpoint: str, params: dict) -> dict:
-        headers = {"x-api-key": self._get_api_key()}
+        headers = {
+            "x-api-key": self._get_api_key(),
+            "user-agent": f"gpt-oss/{_GPT_OSS_VERSION}",
+        }
         async with session.get(f"{self.BASE_URL}{endpoint}", params=params, headers=headers) as resp:
             if resp.status != 200:
                 raise BackendError(


### PR DESCRIPTION
Add user-agent to headers so its easier to track and run analytics on where the request is originating from.
Updated the base Backend class methods. The user-agent `gpt-oss/_GPT_OSS_VERSION` will now be included in all API requests so all calls from gpt-oss are identifiable.

Changes:
Updated the user-agent to use the actual project version from the package metadata. It will use "0.0.8" (the current version in pyproject.toml) or whatever version is installed.

Testing: 
Ran the following code to test and ensure the user-agent is printed out.

```
import asyncio
import os
import datetime
from aiohttp import ClientSession, TraceConfig
from gpt_oss.tools.simple_browser.backend import YouComBackend
from gpt_oss.tools.simple_browser import SimpleBrowserTool

async def log_headers(session, ctx, params):
    print(f"{params.method} Request:")
    print(f"URL: {params.url}")
    print("Headers:")
    for key, value in params.headers.items():
        if key.lower() == "x-api-key":
            print(f"{key}: {value[:2]}...")
        else:
            print(f"{key}: {value}")

async def test():
    """Test that user-agent header is sent with requests."""
    
    if API_KEY == "your-api-key-here":
        print("No API_KEY set")
        return
    
    print("Testing user-agent header with YouComBackend")
    print(f"API Key: {API_KEY[:2]}...\n")
    
    # Set up request tracing
    trace_config = TraceConfig()
    trace_config.on_request_start.append(log_headers)
    
    # Create backend and tool
    backend = YouComBackend(source="web")
    browser_tool = SimpleBrowserTool(backend=backend)
    
    # Make a simple search request
    print("Making a search request...")
    
    async with ClientSession(trace_configs=[trace_config]) as session:
        try:
            # This will trigger a GET request with user-agent header
            result = await backend.search("python", topn=2, session=session)
            print(f"Search successful! Found {len(result.urls)} results")
        except Exception as e:
            print(f"Error: {e}")
            print("(This might be expected if API key is invalid)")


if __name__ == "__main__":
    asyncio.run(test())

```

This should print out

```
Testing user-agent header with YouComBackend
API Key: a2...

Making a search request...
GET Request:
URL: https://api.ydc-index.io/v1/search?query=python&count=2
Headers:
x-api-key: a2...
user-agent: gpt-oss/0.0.8
Search successful! Found 2 results
```