### PR TITLE
Fix ImportError in reference-system-prompt.py

### DIFF
--- a/gpt-oss-mcp-server/reference-system-prompt.py
+++ b/gpt-oss-mcp-server/reference-system-prompt.py
@@ -3,7 +3,9 @@ import datetime
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
 from gpt_oss.tools.simple_browser.backend import YouComBackend
 from gpt_oss.tools.python_docker.docker_tool import PythonTool
-from gpt_oss.tokenizer import tokenizer
+from gpt_oss.tokenizer import get_tokenizer
+
+tokenizer = get_tokenizer()
 
 from openai_harmony import (
     Conversation,


### PR DESCRIPTION
When trying to run `gpt-oss-mcp-server/reference-system-prompt.py`, the script fails with the error:
```
ImportError: cannot import name 'tokenizer' from 'gpt_oss.tokenizer'
```

This PR changes the import from `tokenizer` to `get_tokenizer`, analogous to the previously merged PR: https://github.com/openai/gpt-oss/pull/32 for the `reference-system-prompt.py` script.

With this PR, the script now successfully prints the reference system prompt again.