### PR TITLE
Add `gpt-oss-tvm` as a TVM work in `awesome-gpt-oss.md`

### DIFF
--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -36,6 +36,8 @@ This is a list of guides and resources to help you get started with the gpt-oss 
 - llama.cpp
   - [Running gpt-oss with llama.cpp](https://github.com/ggml-org/llama.cpp/discussions/15396)
   - [Running gpt-oss with Unsloth GGUFs](https://docs.unsloth.ai/new/gpt-oss-how-to-run-and-fine-tune#run-gpt-oss-20b)
+- TVM
+  - [Compile & Run gpt-oss with TVM](https://github.com/brekkylab/gpt-oss-tvm)
 
 ### Server
 


### PR DESCRIPTION
## Introduction

Hello :)
I suggest to add a link to a project: [gpt-oss-tvm](https://github.com/brekkylab/gpt-oss-tvm), that aims to compile gpt-oss model using [Apache TVM](https://github.com/apache/tvm) and run it on the target device.

AFAIK, this is the first attempt to compile gpt-oss model itself with TVM (including MLC LLM: A TVM-based LLM execution framework created by the team that developed TVM).

You can visit the [project wiki](https://github.com/brekkylab/gpt-oss-tvm/wiki) to read the contribution that seeks to implement TVM-based compilation of gpt-oss model while maintaining the consistency with this reference repository.

### Comparison with llama.cpp
`TVM`-based approaches are often compared to `llama.cpp` ones in discussions around running LLM models. I want to emphasize that these two have different goals and are not substitutes for each other.

Unlike llama.cpp-based approaches, which focuses on compiling the LLM execution engine while treating model operations themselves as fixed and pre-defined, this TVM-based project `gpt-oss-tvm` explores executing gpt-oss by compiling the model’s operations directly.
The TVM-based approach emphasizes correctness and architectural fidelity to the reference model by expressing execution behavior directly in TVM’s IR, while enabling compiler-level optimization of model computations across different hardware backends.

---

We would appreciate your consideration of this suggestion. @dkundel-openai :)