### PR TITLE
fix: bare except → except Exception in model weight loading

### DIFF
--- a/gpt_oss/torch/model.py
+++ b/gpt_oss/torch/model.py
@@ -434,7 +434,7 @@ class Transformer(torch.nn.Module):
                 ]
             try:
                 param.data.copy_(loaded_tensor)
-            except:
+            except Exception:
                 print(f"{name=} {param.data.shape=} {loaded_tensor.shape=}")
                 raise
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `gpt_oss/torch/model.py:437` (checkpoint loading error handler).

Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`, which can prevent clean interruption during long model loading operations.