### PR TITLE
Fix apply_patch prompt: use `-` not `*` to remove text

### DIFF
--- a/gpt_oss/tools/apply_patch.md
+++ b/gpt_oss/tools/apply_patch.md
@@ -28,7 +28,7 @@ May be immediately followed by *** Move to: <new path> if you want to rename the
 Then one or more “hunks”, each introduced by @@ (optionally followed by a hunk header).
 Within a hunk each line starts with:
 
-- for inserted text,
++ for inserted text,
 
 - for removed text, or
   space ( ) for context.


### PR DESCRIPTION
Fixed the explanation of line prefixes in a hunk, ensuring consistency with apply_patch tool's expectations.

```
- for inserted text,

* for removed text, or
  space ( ) for context.
```

should be

```
+ for inserted text,

- for removed text, or
  space ( ) for context.
```

This file is injected in chat.py:

```
    if args.apply_patch:
        apply_patch_instructions = Path(apply_patch.__file__).parent / "apply_patch.md"
        developer_message = ""
```

Later apply_patch.py expects `-`, not `*`:

```
        last_mode = mode
        if s == "":
            s = " "
        if s[0] == "+":
            mode = "add"
        elif s[0] == "-":
            mode = "delete"
        elif s[0] == " ":
            mode = "keep"
        else:
```

