### PR TITLE
use real exa api responses in backend tests

### DIFF
--- a/tests/gpt_oss/tools/simple_browser/test_backend.py
+++ b/tests/gpt_oss/tools/simple_browser/test_backend.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from typing import Generator, Any
 from unittest import mock
@@ -67,9 +68,12 @@ async def test_youcom_backend_fetch(mock_session_get):
         assert result.text == "\nURL: https://www.example.com/fetch1\nFetch Result 1 text"
 
 
-def mock_exa_environ_get(name: str, default: Any = "test_api_key"):
-    assert name in ["EXA_API_KEY"]
-    return default
+_real_os_environ_get = os.environ.get
+
+def mock_exa_environ_get(name: str, default: Any = None):
+    if name == "EXA_API_KEY":
+        return "test_api_key"
+    return _real_os_environ_get(name, default)
 
 def test_exa_backend():
     backend = ExaBackend(source="web")
@@ -79,34 +83,50 @@ def test_exa_backend():
 @mock.patch("aiohttp.ClientSession.post")
 async def test_exa_backend_search(mock_session_post):
     backend = ExaBackend(source="web")
+    # real response from: POST https://api.exa.ai/search
+    # {"query": "openai gpt-oss open source model", "numResults": 2, "contents": {"text": true, "summary": true}}
     api_response = {
         "results": [
-            {"title": "Result 1", "url": "https://www.example.com/1", "summary": "Result 1 summary"},
-            {"title": "Result 2", "url": "https://www.example.com/2", "summary": "Result 2 summary"},
+            {
+                "title": "openai/gpt-oss: gpt-oss-120b and gpt-oss-20b are two open-weight ...",
+                "url": "https://github.com/openai/gpt-oss",
+                "summary": "The webpage introduces gpt-oss, a series of open-weight language models developed by OpenAI, designed for high reasoning, agentic tasks, and versatile developer applications.",
+            },
+            {
+                "title": "OpenAI Returns to Open-Source Roots with GPT-OSS Models | AI News",
+                "url": "https://opentools.ai/news/openai-returns-to-open-source-roots-with-gpt-oss-models",
+                "summary": "OpenAI has released two open-source language models, gpt-oss-120b and gpt-oss-20b, under the Apache 2.0 license, marking a return to its open-source roots.",
+            },
         ]
     }
     with mock.patch("os.environ.get", wraps=mock_exa_environ_get):
         mock_session_post.return_value = MockAiohttpResponse(api_response, 200)
         async with ClientSession() as session:
-            result = await backend.search(query="test", topn=10, session=session)
-        assert result.title == "test"
-        assert result.urls == {"0": "https://www.example.com/1", "1": "https://www.example.com/2"}
+            result = await backend.search(query="openai gpt-oss open source model", topn=2, session=session)
+        assert result.title == "openai gpt-oss open source model"
+        assert result.urls == {"0": "https://github.com/openai/gpt-oss", "1": "https://opentools.ai/news/openai-returns-to-open-source-roots-with-gpt-oss-models"}
 
 @pytest.mark.asyncio
 @mock.patch("aiohttp.ClientSession.post")
 async def test_exa_backend_fetch(mock_session_post):
     backend = ExaBackend(source="web")
+    # real response from: POST https://api.exa.ai/contents
+    # {"urls": ["https://github.com/openai/gpt-oss"], "text": {"includeHtmlTags": true}}
     api_response = {
         "results": [
-            {"title": "Fetch Result 1", "url": "https://www.example.com/fetch1", "text": "<div>Fetch Result 1 text</div>"},
+            {
+                "title": "openai/gpt-oss",
+                "url": "https://github.com/openai/gpt-oss",
+                "text": "<h1>Repository: openai/gpt-oss</h1><p>gpt-oss-120b and gpt-oss-20b are two open-weight language models by OpenAI</p>",
+            },
         ]
     }
     with mock.patch("os.environ.get", wraps=mock_exa_environ_get):
         mock_session_post.return_value = MockAiohttpResponse(api_response, 200)
         async with ClientSession() as session:
-            result = await backend.fetch(url="https://www.example.com/fetch1", session=session)
-        assert result.title == "Fetch Result 1"
-        assert result.text == "\nURL: https://www.example.com/fetch1\nFetch Result 1 text"
+            result = await backend.fetch(url="https://github.com/openai/gpt-oss", session=session)
+        assert result.title == "openai/gpt-oss"
+        assert result.text == "\nURL: https://github.com/openai/gpt-oss\n# Repository: openai/gpt-oss \n\ngpt-oss-120b and gpt-oss-20b are two open-weight language models by OpenAI"
 
 
     


### PR DESCRIPTION
the exa backend tests were using example.com placeholder urls which is not great for validating real api behavior. replaced the mock data with actual responses from the exa search and contents apis, using the same params gpt-oss sends:

- search test uses real results from `POST /search` with `contents.text + contents.summary` for query "openai gpt-oss open source model"
- fetch test uses real response from `POST /contents` with `text.includeHtmlTags` for the openai/gpt-oss github page
- fixed `mock_exa_environ_get` to passthrough non-EXA_API_KEY env vars instead of asserting, which was fragile with pytest internals