### PR TITLE
[codex] default browser backend to You.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ codex -p oss
 ### Browser
 
 > [!WARNING]
-> This implementation is purely for educational purposes and should not be used in production. You should implement your own equivalent of the [`ExaBackend`](gpt_oss/tools/simple_browser/backend.py) class with your own browsing environment. Currently we have available `ExaBackend` and `YouComBackend`. 
+> This implementation is purely for educational purposes and should not be used in production. You should implement your own equivalent of the [`YouComBackend`](gpt_oss/tools/simple_browser/backend.py) or [`ExaBackend`](gpt_oss/tools/simple_browser/backend.py) class with your own browsing environment. Currently we have available `YouComBackend` and `ExaBackend`.
 
 Both gpt-oss models were trained with the capability to browse using the `browser` tool that exposes the following three methods:
 
@@ -440,21 +440,22 @@ To enable the browser tool, you'll have to place the definition into the `system
 
 ```python
 import datetime
+import os
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
-from gpt_oss.tools.simple_browser.backend import ExaBackend
+from gpt_oss.tools.simple_browser.backend import ExaBackend, YouComBackend
 from openai_harmony import SystemContent, Message, Conversation, Role, load_harmony_encoding, HarmonyEncodingName
 
 encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
-# Depending on the choice of the browser backend you need corresponding env variables setup
-# Exa backend requires the EXA_API_KEY environment variable,
-# while for You.com you need the YDC_API_KEY environment variable set
-backend = ExaBackend(
-    source="web",
-)
-# backend = YouComBackend(
-#  source="web",
-# )
+# You.com is the default browser backend and requires YDC_API_KEY.
+# To use Exa instead, set BROWSER_BACKEND=exa and EXA_API_KEY.
+tool_backend = os.getenv("BROWSER_BACKEND", "youcom")
+if tool_backend == "youcom":
+    backend = YouComBackend(source="web")
+elif tool_backend == "exa":
+    backend = ExaBackend(source="web")
+else:
+    raise ValueError(f"Invalid tool backend: {tool_backend}")
 browser_tool = SimpleBrowserTool(backend=backend)
 
 # create a basic system prompt

--- a/gpt-oss-mcp-server/browser_server.py
+++ b/gpt-oss-mcp-server/browser_server.py
@@ -14,7 +14,7 @@ class AppContext:
 
     def create_or_get_browser(self, session_id: str) -> SimpleBrowserTool:
         if session_id not in self.browsers:
-            tool_backend = os.getenv("BROWSER_BACKEND", "exa")
+            tool_backend = os.getenv("BROWSER_BACKEND", "youcom")
             if tool_backend == "youcom":
                 backend = YouComBackend(source="web")
             elif tool_backend == "exa":

--- a/gpt-oss-mcp-server/reference-system-prompt.py
+++ b/gpt-oss-mcp-server/reference-system-prompt.py
@@ -1,7 +1,8 @@
 import datetime
+import os
 
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
-from gpt_oss.tools.simple_browser.backend import ExaBackend
+from gpt_oss.tools.simple_browser.backend import ExaBackend, YouComBackend
 from gpt_oss.tools.python_docker.docker_tool import PythonTool
 from gpt_oss.tokenizer import tokenizer
 
@@ -22,7 +23,13 @@ system_message_content = (SystemContent.new().with_reasoning_effort(
     ReasoningEffort.LOW).with_conversation_start_date(
         datetime.datetime.now().strftime("%Y-%m-%d")))
 
-backend = ExaBackend(source="web")
+tool_backend = os.getenv("BROWSER_BACKEND", "youcom")
+if tool_backend == "youcom":
+    backend = YouComBackend(source="web")
+elif tool_backend == "exa":
+    backend = ExaBackend(source="web")
+else:
+    raise ValueError(f"Invalid tool backend: {tool_backend}")
 browser_tool = SimpleBrowserTool(backend=backend)
 system_message_content = system_message_content.with_tools(
     browser_tool.tool_config)

--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -85,7 +85,7 @@ def main(args):
     )
 
     if args.browser:
-        tool_backend = os.getenv("BROWSER_BACKEND", "exa")
+        tool_backend = os.getenv("BROWSER_BACKEND", "youcom")
         if tool_backend == "youcom":
             backend = YouComBackend(source="web")
         elif tool_backend == "exa":

--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -1147,7 +1147,7 @@ def create_api_server(
         )
 
         if use_browser_tool:
-            tool_backend = os.getenv("BROWSER_BACKEND", "exa")
+            tool_backend = os.getenv("BROWSER_BACKEND", "youcom")
             if tool_backend == "youcom":
                 backend = YouComBackend(source="web")
             elif tool_backend == "exa":


### PR DESCRIPTION
## Summary
- default browser backend selection to You.com when `BROWSER_BACKEND` is unset
- keep Exa available via `BROWSER_BACKEND=exa`
- update browser docs to cover both You.com and Exa

## Why
The browser examples and runtime entry points previously preferred Exa by default. This makes You.com the default while preserving an explicit Exa opt-in through the existing environment variable.

## Validation
- `python -m py_compile gpt-oss-mcp-server/reference-system-prompt.py gpt-oss-mcp-server/browser_server.py gpt_oss/chat.py gpt_oss/responses_api/api_server.py`
- `git diff --check`

Skipped `tests/gpt_oss/tools/simple_browser/test_backend.py` per request.