### PR TITLE
fix(evals): don't leak non-answer first char from abcd grader fallback

### DIFF
--- a/gpt_oss/evals/abcd_grader.py
+++ b/gpt_oss/evals/abcd_grader.py
@@ -98,7 +98,11 @@ def extract_abcd(text: str) -> str | None:
     ))
     for _, match, letter in matches:
         return letter
-    return text.removeprefix('**')[:1]
+    # Fallback: a bare (optionally bold) leading letter such as "A" or "**A**".
+    # Only accept an actual choice letter; otherwise return None as documented,
+    # rather than leaking the first character of an unparseable response.
+    fallback = text.removeprefix('**')[:1].upper()
+    return fallback if fallback in ('A', 'B', 'C', 'D') else None
 
 
 def main():

--- a/gpt_oss/evals/abcd_grader.py
+++ b/gpt_oss/evals/abcd_grader.py
@@ -98,11 +98,14 @@ def extract_abcd(text: str) -> str | None:
     ))
     for _, match, letter in matches:
         return letter
-    # Fallback: a bare (optionally bold) leading letter such as "A" or "**A**".
-    # Only accept an actual choice letter; otherwise return None as documented,
-    # rather than leaking the first character of an unparseable response.
-    fallback = text.removeprefix('**')[:1].upper()
-    return fallback if fallback in ('A', 'B', 'C', 'D') else None
+    # Fallback: accept only a response whose entire content is a single bare,
+    # optionally bold/italic, choice letter (e.g. "A", "**A**", "a", "B)").
+    # Anything longer (e.g. "because ...", "dunno") is not an answer, so return
+    # None as documented rather than leaking its first character.
+    bare = re.fullmatch(
+        r'\s*[*_]{0,2}\s*([ABCD])\s*[*_]{0,2}\s*[.):\]]?\s*', text, re.IGNORECASE
+    )
+    return bare.group(1).upper() if bare else None
 
 
 def main():

--- a/tests/gpt_oss/evals/test_abcd_grader.py
+++ b/tests/gpt_oss/evals/test_abcd_grader.py
@@ -1,0 +1,20 @@
+from gpt_oss.evals.abcd_grader import extract_abcd
+
+
+def test_extracts_explicit_answer():
+    assert extract_abcd("Answer: B") == "B"
+
+
+def test_extracts_markdown_wrapped_answer():
+    assert extract_abcd("**Answer:** A") == "A"
+
+
+def test_bare_letter_still_extracted():
+    assert extract_abcd("C") == "C"
+
+
+def test_returns_none_for_unparseable_text():
+    # Regression: the fallback used to return the first character of the text
+    # (e.g. "T"), violating the documented `-> str | None` choice contract.
+    assert extract_abcd("The answer is unclear.") is None
+    assert extract_abcd("") is None

--- a/tests/gpt_oss/evals/test_abcd_grader.py
+++ b/tests/gpt_oss/evals/test_abcd_grader.py
@@ -13,8 +13,30 @@ def test_bare_letter_still_extracted():
     assert extract_abcd("C") == "C"
 
 
+def test_bare_bold_letter_extracted():
+    assert extract_abcd("**A**") == "A"
+    assert extract_abcd("**b**") == "B"
+
+
+def test_bare_letter_with_surrounding_whitespace():
+    assert extract_abcd("  **B**  ") == "B"
+    assert extract_abcd("\nA") == "A"
+
+
+def test_bare_letter_with_trailing_punctuation():
+    assert extract_abcd("A.") == "A"
+    assert extract_abcd("A)") == "A"
+
+
 def test_returns_none_for_unparseable_text():
     # Regression: the fallback used to return the first character of the text
     # (e.g. "T"), violating the documented `-> str | None` choice contract.
     assert extract_abcd("The answer is unclear.") is None
     assert extract_abcd("") is None
+
+
+def test_does_not_leak_leading_lowercase_letter():
+    # Regression: a non-answer that merely *starts* with a/b/c/d must not be
+    # scored as that choice (the fallback only accepts a whole bare letter).
+    assert extract_abcd("because the answer is unclear") is None
+    assert extract_abcd("dunno") is None


### PR DESCRIPTION
## Summary

`extract_abcd` (in `gpt_oss/evals/abcd_grader.py`) is documented to return `'A'`, `'B'`, `'C'`, `'D'`, or `None`. But when no answer pattern matches, its fallback returns:

```python
return text.removeprefix('**')[:1]
```

— the **first character of the text**, even when that character is not a choice letter (and without upper-casing). So:

- `"The answer is unclear."` → `"T"` (a non-choice "answer")
- `""` → `""`
- bare lowercase `"a"` → `"a"` (not normalized to `"A"`)

This violates the documented `-> str | None` contract and can mis-grade evals: an unparseable response is scored as whatever its first character happens to be, and `"B is wrong..."`-style leading characters leak through.

## Fix

Validate the fallback character against the choice set (and upper-case it), returning `None` otherwise:

```python
fallback = text.removeprefix('**')[:1].upper()
return fallback if fallback in ('A', 'B', 'C', 'D') else None
```

- Bare letters still resolve: `"A"`, `"**A**"`, `"a"` → `"A"`.
- Non-answers now return `None` as documented: `"The answer is unclear."`, `""` → `None`.
- Pattern-matched answers are unchanged.

## Tests

Adds `tests/gpt_oss/evals/test_abcd_grader.py` covering explicit/markdown/bare-letter extraction and the `None` regression. All pass.
