### PR TITLE
Add api_key constructor param to YouComBackend and improve missing-key error

### DIFF
--- a/gpt_oss/tools/simple_browser/backend.py
+++ b/gpt_oss/tools/simple_browser/backend.py
@@ -193,13 +193,19 @@ class YouComBackend(Backend):
     """Backend that uses the You.com Search API."""
 
     source: str = chz.field(doc="Description of the backend source")
+    api_key: str | None = chz.field(
+        doc="You.com API key. Uses YDC_API_KEY environment variable if not provided.",
+        default=None,
+    )
 
     BASE_URL: str = "https://api.ydc-index.io"
 
     def _get_api_key(self) -> str:
-        key = os.environ.get("YDC_API_KEY")
+        key = self.api_key or os.environ.get("YDC_API_KEY")
         if not key:
-            raise BackendError("You.com API key not provided")
+            raise BackendError(
+                "You.com API key not provided. Get one at https://you.com/platform"
+            )
         return key
 
     

--- a/tests/gpt_oss/tools/simple_browser/test_backend.py
+++ b/tests/gpt_oss/tools/simple_browser/test_backend.py
@@ -29,6 +29,11 @@ def test_youcom_backend():
     backend = YouComBackend(source="web")
     assert backend.source == "web"
 
+def test_youcom_backend_api_key_param():
+    backend = YouComBackend(source="web", api_key="my_custom_key")
+    assert backend.api_key == "my_custom_key"
+    assert backend._get_api_key() == "my_custom_key"
+
 @pytest.mark.asyncio
 @mock.patch("aiohttp.ClientSession.get")
 async def test_youcom_backend_search(mock_session_get):


### PR DESCRIPTION
## Summary
- Add `api_key: str | None` constructor param to `YouComBackend` (matches `ExaBackend`)
- `_get_api_key` now checks `self.api_key` first, then falls back to `YDC_API_KEY` env var
- Missing-key error message now includes the signup URL (`https://you.com/platform`)

## Why
`YouComBackend` previously only read the `YDC_API_KEY` environment variable, while `ExaBackend` accepts an `api_key` constructor param with env fallback. This adds the same pattern for consistency. The signup URL in the error message helps users get a key directly from the stack trace.

## Validation
- All existing tests pass (`pytest tests/gpt_oss/tools/simple_browser/test_backend.py`)
- Added test for `api_key` constructor param priority
- No changes to `search` or `fetch` methods