### PR TITLE
Harden YouComBackend search response parsing

### DIFF
--- a/gpt_oss/tools/simple_browser/backend.py
+++ b/gpt_oss/tools/simple_browser/backend.py
@@ -212,16 +212,17 @@ class YouComBackend(Backend):
             {"query": query, "count": topn},
         )
         # make a simple HTML page to work with browser format
+        results = data.get("results", {})
         web_titles_and_urls, news_titles_and_urls = [], []
-        if "web" in data["results"]:
+        if "web" in results:
             web_titles_and_urls = [
                 (result["title"], result["url"], result["snippets"])
-                for result in data["results"]["web"]
+                for result in results["web"]
             ]
-        if "news" in data["results"]:
+        if "news" in results:
             news_titles_and_urls = [
                 (result["title"], result["url"], result["description"])
-                for result in data["results"]["news"]
+                for result in results["news"]
             ]
         titles_and_urls = web_titles_and_urls + news_titles_and_urls
         html_page = f"""

--- a/tests/gpt_oss/tools/simple_browser/test_backend.py
+++ b/tests/gpt_oss/tools/simple_browser/test_backend.py
@@ -53,6 +53,18 @@ async def test_youcom_backend_search(mock_session_get):
         assert result.urls == {"0": "https://www.example.com/web1", "1": "https://www.example.com/web2", "2": "https://www.example.com/news1", "3": "https://www.example.com/news2"}
 
 @pytest.mark.asyncio
+@mock.patch("aiohttp.ClientSession.get")
+async def test_youcom_backend_search_missing_results_key(mock_session_get):
+    backend = YouComBackend(source="web")
+    api_response = {"error": "rate limited"}
+    with mock.patch("os.environ.get", wraps=mock_os_environ_get):
+        mock_session_get.return_value = MockAiohttpResponse(api_response, 200)
+        async with ClientSession() as session:
+            result = await backend.search(query="test", topn=10, session=session)
+        assert result.title == "test"
+        assert result.urls == {}
+
+@pytest.mark.asyncio
 @mock.patch("aiohttp.ClientSession.post")
 async def test_youcom_backend_fetch(mock_session_get):
     backend = YouComBackend(source="web")


### PR DESCRIPTION
## Summary
- Replace `data["results"]` with `data.get("results", {})` in `YouComBackend.search`
- Extract `results` local variable to reduce repetition

## Why
Direct indexing raises `KeyError` if the API returns an unexpected response shape (e.g. an error payload without a `results` key). Using `.get()` with a default of `{}` makes search gracefully return empty results instead of crashing with an unhandled exception. No changes to `fetch`, which already uses defensive `.get()` and has empty-response checks.

## Validation
- All existing tests pass (`pytest tests/gpt_oss/tools/simple_browser/test_backend.py`)
- Added test for search with missing `results` key in API response