### PR TITLE
Fix final-answer precedence in ABCD eval grading

### DIFF
--- a/gpt_oss/evals/abcd_grader.py
+++ b/gpt_oss/evals/abcd_grader.py
@@ -77,6 +77,14 @@ _PATTERNS = [
     ''', re.MULTILINE),
 ]
 
+# Patterns 0 through 4 explicitly declare an answer using words such as
+# "Answer", "Option", or "Choice". Treat them as one declaration class so a
+# later declaration wins even when the model changes formatting while
+# self-correcting. The remaining patterns are permissive fallbacks and keep
+# their historical first-match behavior so later prose cannot override an
+# earlier fallback answer.
+_NUM_DECLARATION_PATTERNS = 5
+
 
 def extract_abcd(text: str) -> str | None:
     """
@@ -84,20 +92,27 @@ def extract_abcd(text: str) -> str | None:
     'A', 'B', 'C', or 'D' if a correct-answer declaration is found.
     Otherwise return None.
     """
-    matches = []
-    for prio, pat in enumerate(_PATTERNS):
-        m = pat.search(text)
-        if m:
-            letter = m.group(1).upper()
+    declaration_matches = []
+    for prio, pat in enumerate(_PATTERNS[:_NUM_DECLARATION_PATTERNS]):
+        for match in pat.finditer(text):
+            letter = match.group(1).upper()
             if letter in 'ABCD':
-                matches.append((prio, m, letter))
+                declaration_matches.append((prio, match, letter))
 
-    matches.sort(key=lambda triple: (
-        triple[0],
-        len(triple[1].group(0))
-    ))
-    for _, match, letter in matches:
+    if declaration_matches:
+        _, _, letter = max(
+            declaration_matches,
+            key=lambda triple: (triple[1].start(), -triple[0]),
+        )
         return letter
+
+    for pat in _PATTERNS[_NUM_DECLARATION_PATTERNS:]:
+        match = pat.search(text)
+        if match:
+            letter = match.group(1).upper()
+            if letter in 'ABCD':
+                return letter
+
     return text.removeprefix('**')[:1]
 
 
@@ -118,4 +133,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tests/gpt_oss/evals/test_abcd_grader_final_answer.py
+++ b/tests/gpt_oss/evals/test_abcd_grader_final_answer.py
@@ -1,0 +1,41 @@
+from gpt_oss.evals.abcd_grader import extract_abcd
+
+
+def test_latest_explicit_answer_declaration_wins() -> None:
+    text = "Answer: A\nAfter checking the reasoning, I need to correct this.\nAnswer: B"
+
+    assert extract_abcd(text) == "B"
+
+
+def test_latest_markdown_answer_declaration_wins() -> None:
+    text = "**Answer:** A\nAfter checking the reasoning, I need to correct this.\n**Answer:** C"
+
+    assert extract_abcd(text) == "C"
+
+
+def test_latest_declaration_wins_across_answer_and_choice_formats() -> None:
+    text = "Answer: A\nI reconsidered.\nChoice: B"
+
+    assert extract_abcd(text) == "B"
+
+
+def test_latest_declaration_wins_across_plain_and_parenthesized_formats() -> None:
+    text = "Answer: A\nI reconsidered.\nAnswer: (B)"
+
+    assert extract_abcd(text) == "B"
+
+
+def test_explicit_answer_priority_is_preserved() -> None:
+    text = "Answer: A\nA later aside mentions (B), without declaring it as the answer."
+
+    assert extract_abcd(text) == "A"
+
+
+def test_fallback_answer_is_not_overridden_by_later_prose() -> None:
+    text = "D) The fourth option.\nBecause it follows."
+
+    assert extract_abcd(text) == "D"
+
+
+def test_single_answer_declaration_is_unchanged() -> None:
+    assert extract_abcd("Reasoning complete.\nAnswer: D") == "D"


### PR DESCRIPTION
## Summary

Make `extract_abcd()` grade the final explicit answer declaration when a model self-corrects, even if the correction uses a different supported declaration format.

The parser has several explicit `Answer` / `Option` / `Choice` regex variants followed by permissive fallback patterns. Selecting the latest match only within each regex still allowed an earlier `Answer: A` to beat a later `Choice: B` or `Answer: (B)` because the earlier declaration belonged to a higher-priority regex.

Fixes #254.

## Fix

Treat the first five explicit declaration regexes as one declaration class:

- collect valid matches across all `Answer` / `Option` / `Choice` variants;
- select the declaration occurring latest in the response;
- preserve original regex priority only as a tie-break for matches at the same position;
- use the existing permissive fallback patterns only when no explicit declaration exists;
- preserve fallback first-match behavior so later prose cannot override an answer-first response.

## Regression coverage

Adds focused tests verifying that:

- a later `Answer:` declaration overrides an earlier one;
- a later markdown-wrapped declaration overrides an earlier one;
- `Answer: A` followed by `Choice: B` returns `B`;
- `Answer: A` followed by `Answer: (B)` returns `B`;
- an explicit declaration still outranks a later incidental fallback-style mention;
- `D) The fourth option.\nBecause it follows.` still returns `D`;
- a single explicit answer remains unchanged.

The branch is based directly on current `main` and collapsed to one signed-off commit.