### PR TITLE
Preserve eval names in merged result summaries

### DIFF
--- a/gpt_oss/evals/__main__.py
+++ b/gpt_oss/evals/__main__.py
@@ -14,6 +14,24 @@ from .chat_completions_sampler import (
 from .responses_sampler import ResponsesSampler
 
 
+def _collect_merge_metrics(
+    result_paths: dict[tuple[str, str], str],
+) -> list[dict[str, str | float | None]]:
+    merge_metrics = []
+    for (eval_name, model_name), result_filename in result_paths.items():
+        try:
+            with open(result_filename) as f:
+                result = json.load(f)
+        except Exception as e:
+            print(e, result_filename)
+            continue
+        metric = result.get("f1_score", result.get("score", None))
+        merge_metrics.append(
+            {"eval_name": eval_name, "model_name": model_name, "metric": metric}
+        )
+    return merge_metrics
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Evaluate the models.",
@@ -148,7 +166,7 @@ def main():
 
     debug_suffix = "_DEBUG" if args.debug else ""
     print(debug_suffix)
-    mergekey2resultpath = {}
+    mergekey2resultpath: dict[tuple[str, str], str] = {}
     print(f"Running the following evals: {evals}")
     print(f"Running evals for the following models: {models}")
 
@@ -188,21 +206,9 @@ def main():
                 f.write(json.dumps(result_dict, indent=2))
                 print(f"Writing all results to {full_result_filename}")
 
-            mergekey2resultpath[f"{file_stem}"] = result_filename
+            mergekey2resultpath[(eval_name, model_name)] = result_filename
 
-    merge_metrics = []
-    for eval_model_name, result_filename in mergekey2resultpath.items():
-        try:
-            result = json.load(open(result_filename, "r+"))
-        except Exception as e:
-            print(e, result_filename)
-            continue
-        result = result.get("f1_score", result.get("score", None))
-        eval_name = eval_model_name[: eval_model_name.find("_")]
-        model_name = eval_model_name[eval_model_name.find("_") + 1 :]
-        merge_metrics.append(
-            {"eval_name": eval_name, "model_name": model_name, "metric": result}
-        )
+    merge_metrics = _collect_merge_metrics(mergekey2resultpath)
     print(merge_metrics)
     return merge_metrics
 

--- a/tests/gpt_oss/evals/test_eval_summary_identifiers.py
+++ b/tests/gpt_oss/evals/test_eval_summary_identifiers.py
@@ -1,0 +1,37 @@
+import json
+
+from gpt_oss.evals.__main__ import _collect_merge_metrics
+
+
+def test_collect_merge_metrics_preserves_eval_names_with_underscores(tmp_path) -> None:
+    hard_result = tmp_path / "hard.json"
+    hard_result.write_text(json.dumps({"score": 0.75}))
+    consensus_result = tmp_path / "consensus.json"
+    consensus_result.write_text(json.dumps({"score": 0.5}))
+
+    result_paths = {
+        ("healthbench_hard", "gpt-oss-120b-low"): str(hard_result),
+        ("healthbench_consensus", "gpt-oss-20b-high"): str(consensus_result),
+    }
+
+    assert _collect_merge_metrics(result_paths) == [
+        {
+            "eval_name": "healthbench_hard",
+            "model_name": "gpt-oss-120b-low",
+            "metric": 0.75,
+        },
+        {
+            "eval_name": "healthbench_consensus",
+            "model_name": "gpt-oss-20b-high",
+            "metric": 0.5,
+        },
+    ]
+
+
+def test_collect_merge_metrics_keeps_f1_score_precedence(tmp_path) -> None:
+    result_file = tmp_path / "result.json"
+    result_file.write_text(json.dumps({"f1_score": 0.8, "score": 0.2}))
+
+    assert _collect_merge_metrics({("gpqa", "model"): str(result_file)}) == [
+        {"eval_name": "gpqa", "model_name": "model", "metric": 0.8}
+    ]


### PR DESCRIPTION
## Summary

Keep eval and model identifiers as structured values when building the final merged metrics summary.

The CLI currently reconstructs those identifiers by splitting the generated filename at the first underscore. That mislabels built-in evals such as `healthbench_hard` and `healthbench_consensus`: they are reported as `healthbench`, while `hard_...` or `consensus_...` is incorrectly prepended to the model name.

Fixes #257.

## Fix

Store result paths under `(eval_name, model_name)` tuple keys and build the merged summary from those original identifiers. Filenames remain unchanged and are still used only as output paths.

The merge-reading logic is factored into `_collect_merge_metrics()` so the identifier behavior can be tested directly.

## Regression coverage

Adds tests covering:

- `healthbench_hard` and `healthbench_consensus` names containing underscores;
- preservation of the existing `f1_score` preference over `score`.

No eval execution, result-file naming, or metric-selection behavior changes.