### PR TITLE
Fix HealthBench usage normalization for Chat Completions

### DIFF
--- a/gpt_oss/evals/healthbench_eval.py
+++ b/gpt_oss/evals/healthbench_eval.py
@@ -163,10 +163,18 @@ def get_usage_dict(response_usage) -> dict[str, int | None]:
             "total_tokens": None,
         }
 
+    input_tokens = getattr(response_usage, "input_tokens", None)
+    if input_tokens is None:
+        input_tokens = getattr(response_usage, "prompt_tokens", None)
+
+    output_tokens = getattr(response_usage, "output_tokens", None)
+    if output_tokens is None:
+        output_tokens = getattr(response_usage, "completion_tokens", None)
+
     return {
-        "input_tokens": response_usage.input_tokens,
-        "output_tokens": response_usage.output_tokens,
-        "total_tokens": response_usage.total_tokens,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": getattr(response_usage, "total_tokens", None),
         "input_cached_tokens": None,
         "output_reasoning_tokens": None,
     }

--- a/tests/gpt_oss/evals/test_healthbench_usage.py
+++ b/tests/gpt_oss/evals/test_healthbench_usage.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from gpt_oss.evals.healthbench_eval import get_usage_dict
+
+
+def test_get_usage_dict_supports_responses_usage() -> None:
+    usage = SimpleNamespace(input_tokens=120, output_tokens=30, total_tokens=150)
+
+    assert get_usage_dict(usage) == {
+        "input_tokens": 120,
+        "input_cached_tokens": None,
+        "output_tokens": 30,
+        "output_reasoning_tokens": None,
+        "total_tokens": 150,
+    }
+
+
+def test_get_usage_dict_supports_chat_completions_usage() -> None:
+    usage = SimpleNamespace(prompt_tokens=80, completion_tokens=20, total_tokens=100)
+
+    assert get_usage_dict(usage) == {
+        "input_tokens": 80,
+        "input_cached_tokens": None,
+        "output_tokens": 20,
+        "output_reasoning_tokens": None,
+        "total_tokens": 100,
+    }
+
+
+def test_get_usage_dict_handles_missing_usage() -> None:
+    assert get_usage_dict(None) == {
+        "input_tokens": None,
+        "input_cached_tokens": None,
+        "output_tokens": None,
+        "output_reasoning_tokens": None,
+        "total_tokens": None,
+    }


### PR DESCRIPTION
## Summary

Make HealthBench accept token-usage metadata from both sampler APIs supported by the eval CLI.

The Responses API exposes `input_tokens` and `output_tokens`, while Chat Completions exposes `prompt_tokens` and `completion_tokens`. `HealthBenchEval` currently assumes only the Responses field names, so a run using the supported `--sampler chat_completions` path can finish sampling and grading and then fail while building example-level usage metadata.

Fixes #256.

## Fix

`get_usage_dict()` now:

- reads `input_tokens` when present and falls back to `prompt_tokens`;
- reads `output_tokens` when present and falls back to `completion_tokens`;
- preserves the existing normalized output keys and `total_tokens` handling;
- preserves the existing all-`None` result when usage metadata is absent.

## Regression coverage

Adds focused tests for:

- Responses-style usage;
- Chat-Completions-style usage;
- missing usage metadata.

The patch is confined to usage normalization and does not change HealthBench scoring, sampling, grading, or report generation.