### PR TITLE
Make HealthBench bootstrap uncertainty reproducible

### DIFF
--- a/gpt_oss/evals/healthbench_eval.py
+++ b/gpt_oss/evals/healthbench_eval.py
@@ -201,7 +201,11 @@ def _compute_clipped_stats(
     elif stat == "n_samples":
         return len(values)
     elif stat == "bootstrap_std":
-        bootstrap_samples = [np.random.choice(values, len(values)) for _ in range(1000)]
+        rng = np.random.default_rng(0)
+        canonical_values = sorted(values)
+        bootstrap_samples = [
+            rng.choice(canonical_values, len(canonical_values)) for _ in range(1000)
+        ]
         bootstrap_means = [
             _compute_clipped_stats(list(s), "mean") for s in bootstrap_samples
         ]

--- a/tests/gpt_oss/evals/test_healthbench_bootstrap.py
+++ b/tests/gpt_oss/evals/test_healthbench_bootstrap.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from gpt_oss.evals.healthbench_eval import _compute_clipped_stats
+
+
+def test_bootstrap_std_is_independent_of_global_numpy_seed() -> None:
+    values = [0.0, 0.25, 0.5, 1.0]
+
+    np.random.seed(1)
+    first = _compute_clipped_stats(values, "bootstrap_std")
+    np.random.seed(999)
+    second = _compute_clipped_stats(values, "bootstrap_std")
+
+    assert first == second
+
+
+def test_bootstrap_std_does_not_advance_global_numpy_rng() -> None:
+    values = [0.0, 0.25, 0.5, 1.0]
+
+    np.random.seed(123)
+    expected_next = np.random.random()
+
+    np.random.seed(123)
+    _compute_clipped_stats(values, "bootstrap_std")
+    actual_next = np.random.random()
+
+    assert actual_next == expected_next
+
+
+def test_bootstrap_std_is_independent_of_input_order() -> None:
+    values = [0.0, 0.25, 0.5, 1.0, 0.75]
+
+    first = _compute_clipped_stats(values, "bootstrap_std")
+    second = _compute_clipped_stats([1.0, 0.5, 0.0, 0.75, 0.25], "bootstrap_std")
+
+    assert first == second


### PR DESCRIPTION
## Summary

Make HealthBench `bootstrap_std` deterministic and independent of both NumPy's process-global RNG state and threaded result ordering.

HealthBench aggregates per-example results returned from threaded evaluation. A fixed local RNG makes bootstrap sampling reproducible only for a fixed input sequence; if the same score multiset arrives in a different completion order, finite bootstrap resamples can still produce a different standard deviation.

Fixes #260.

## Fix

Use a local `np.random.default_rng(0)` generator and canonicalize bootstrap input ordering before the 1,000 resamples.

This makes the uncertainty estimate reproducible for the same score multiset regardless of prior global NumPy RNG use or thread completion order, without mutating the caller's values.

## Regression coverage

Adds tests verifying that:

- changing the global NumPy seed does not change `bootstrap_std` for the same values;
- computing `bootstrap_std` does not advance the process-global NumPy RNG;
- permuting the same score values produces the same `bootstrap_std`.

The bootstrap sample count, clipping behavior, mean calculation, and reported metric names are unchanged.