### PR TITLE
Fail fast on permanent eval sampler API errors

### DIFF
--- a/gpt_oss/evals/chat_completions_sampler.py
+++ b/gpt_oss/evals/chat_completions_sampler.py
@@ -14,6 +14,10 @@ OPENAI_SYSTEM_MESSAGE_CHATGPT = (
 )
 
 
+class _EmptyResponseError(Exception):
+    pass
+
+
 class ChatCompletionsSampler(SamplerBase):
     """Sample from a Chat Completions compatible API."""
 
@@ -69,7 +73,7 @@ class ChatCompletionsSampler(SamplerBase):
                     message_list.append(self._pack_message("assistant", choice.message.reasoning))
 
                 if not content:
-                    raise ValueError("OpenAI API returned empty response; retrying")
+                    raise _EmptyResponseError("OpenAI API returned empty response; retrying")
                 return SamplerResponse(
                     response_text=content,
                     response_metadata={"usage": response.usage},
@@ -82,12 +86,29 @@ class ChatCompletionsSampler(SamplerBase):
                     response_metadata={"usage": None},
                     actual_queried_message_list=message_list,
                 )
-            except Exception as e:
+            except openai.APIStatusError as e:
+                if e.status_code not in {408, 409, 429} and e.status_code < 500:
+                    raise
                 exception_backoff = 2 ** trial  # exponential back off
                 print(
-                    f"Rate limit exception so wait and retry {trial} after {exception_backoff} sec",
+                    f"Retryable API exception so wait and retry {trial} after {exception_backoff} sec",
                     e,
                 )
                 time.sleep(exception_backoff)
                 trial += 1
-            # unknown error shall throw exception
+            except openai.APIConnectionError as e:
+                exception_backoff = 2 ** trial  # exponential back off
+                print(
+                    f"Connection exception so wait and retry {trial} after {exception_backoff} sec",
+                    e,
+                )
+                time.sleep(exception_backoff)
+                trial += 1
+            except _EmptyResponseError as e:
+                exception_backoff = 2 ** trial  # exponential back off
+                print(
+                    f"Empty response so wait and retry {trial} after {exception_backoff} sec",
+                    e,
+                )
+                time.sleep(exception_backoff)
+                trial += 1

--- a/gpt_oss/evals/responses_sampler.py
+++ b/gpt_oss/evals/responses_sampler.py
@@ -74,12 +74,21 @@ class ResponsesSampler(SamplerBase):
                     response_metadata={"usage": None},
                     actual_queried_message_list=message_list,
                 )
-            except Exception as e:
-                exception_backoff = 2**trial  # expontial back off
+            except openai.APIStatusError as e:
+                if e.status_code not in {408, 409, 429} and e.status_code < 500:
+                    raise
+                exception_backoff = 2**trial  # exponential back off
                 print(
-                    f"Rate limit exception so wait and retry {trial} after {exception_backoff} sec",
+                    f"Retryable API exception so wait and retry {trial} after {exception_backoff} sec",
                     e,
                 )
                 time.sleep(exception_backoff)
                 trial += 1
-            # unknown error shall throw exception
+            except openai.APIConnectionError as e:
+                exception_backoff = 2**trial  # exponential back off
+                print(
+                    f"Connection exception so wait and retry {trial} after {exception_backoff} sec",
+                    e,
+                )
+                time.sleep(exception_backoff)
+                trial += 1

--- a/tests/gpt_oss/evals/test_sampler_error_retry.py
+++ b/tests/gpt_oss/evals/test_sampler_error_retry.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import gpt_oss.evals.chat_completions_sampler as chat_module
+import gpt_oss.evals.responses_sampler as responses_module
+from gpt_oss.evals.chat_completions_sampler import ChatCompletionsSampler
+from gpt_oss.evals.responses_sampler import ResponsesSampler
+
+
+class PermanentAPIStatusError(Exception):
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}")
+
+
+def _responses_sampler_raising(error: Exception) -> ResponsesSampler:
+    sampler = object.__new__(ResponsesSampler)
+    sampler.client = SimpleNamespace(
+        responses=SimpleNamespace(create=Mock(side_effect=error))
+    )
+    sampler.model = "test-model"
+    sampler.developer_message = None
+    sampler.temperature = 1.0
+    sampler.max_tokens = 16
+    sampler.reasoning_model = False
+    sampler.reasoning_effort = None
+    return sampler
+
+
+def _chat_sampler_raising(error: Exception) -> ChatCompletionsSampler:
+    sampler = object.__new__(ChatCompletionsSampler)
+    sampler.client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=Mock(side_effect=error))
+        )
+    )
+    sampler.model = "test-model"
+    sampler.system_message = None
+    sampler.temperature = 1.0
+    sampler.max_tokens = 16
+    sampler.reasoning_model = False
+    sampler.reasoning_effort = None
+    return sampler
+
+
+def test_responses_sampler_surfaces_permanent_api_status_without_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = PermanentAPIStatusError(401)
+    sampler = _responses_sampler_raising(error)
+    sleep = Mock()
+    monkeypatch.setattr(responses_module.openai, "APIStatusError", PermanentAPIStatusError)
+    monkeypatch.setattr(responses_module.time, "sleep", sleep)
+
+    with pytest.raises(PermanentAPIStatusError) as raised:
+        sampler([{"role": "user", "content": "hello"}])
+
+    assert raised.value is error
+    sleep.assert_not_called()
+
+
+def test_chat_sampler_surfaces_permanent_api_status_without_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = PermanentAPIStatusError(403)
+    sampler = _chat_sampler_raising(error)
+    sleep = Mock()
+    monkeypatch.setattr(chat_module.openai, "APIStatusError", PermanentAPIStatusError)
+    monkeypatch.setattr(chat_module.time, "sleep", sleep)
+
+    with pytest.raises(PermanentAPIStatusError) as raised:
+        sampler([{"role": "user", "content": "hello"}])
+
+    assert raised.value is error
+    sleep.assert_not_called()


### PR DESCRIPTION
## Summary

Stop the eval samplers from retrying permanent API failures forever.

Both `ResponsesSampler` and `ChatCompletionsSampler` currently put every exception other than `BadRequestError` into an unbounded exponential-backoff loop. That includes non-retryable API status failures such as authentication, permission, not-found, and unprocessable-request errors.

Fixes #262.

## Fix

Both samplers now:

- preserve the existing explicit `BadRequestError` behavior;
- retry API status codes 408, 409, 429, and 5xx with the existing exponential backoff;
- retry `APIConnectionError` with the existing exponential backoff;
- immediately re-raise other `APIStatusError` values;
- allow unexpected non-API exceptions to propagate instead of treating them as rate limits.

Chat Completions still retries its intentional empty-success-response condition through a dedicated internal exception, preserving that existing behavior without making arbitrary `ValueError` instances retryable.

## Regression coverage

Adds tests for both sampler implementations verifying that representative permanent status failures are surfaced immediately and do not invoke `time.sleep`.

The retry delay and retryable-status behavior are otherwise unchanged.