### PR TITLE
Keep Chat Completions reasoning out of eval prompt history

### DIFF
--- a/gpt_oss/evals/chat_completions_sampler.py
+++ b/gpt_oss/evals/chat_completions_sampler.py
@@ -65,14 +65,16 @@ class ChatCompletionsSampler(SamplerBase):
 
                 choice = response.choices[0]
                 content = choice.message.content
-                if getattr(choice.message, "reasoning", None):
-                    message_list.append(self._pack_message("assistant", choice.message.reasoning))
+                reasoning = getattr(choice.message, "reasoning", None)
 
                 if not content:
                     raise ValueError("OpenAI API returned empty response; retrying")
+                response_metadata = {"usage": response.usage}
+                if reasoning:
+                    response_metadata["reasoning"] = reasoning
                 return SamplerResponse(
                     response_text=content,
-                    response_metadata={"usage": response.usage},
+                    response_metadata=response_metadata,
                     actual_queried_message_list=message_list,
                 )
             except openai.BadRequestError as e:

--- a/tests/gpt_oss/evals/test_chat_sampler_reasoning_history.py
+++ b/tests/gpt_oss/evals/test_chat_sampler_reasoning_history.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from gpt_oss.evals.chat_completions_sampler import ChatCompletionsSampler
+
+
+def _sampler_with_response(response) -> ChatCompletionsSampler:
+    sampler = object.__new__(ChatCompletionsSampler)
+    sampler.client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=Mock(return_value=response))
+        )
+    )
+    sampler.model = "test-model"
+    sampler.system_message = None
+    sampler.temperature = 1.0
+    sampler.max_tokens = 16
+    sampler.reasoning_model = False
+    sampler.reasoning_effort = None
+    return sampler
+
+
+def test_reasoning_is_not_added_to_queried_prompt_history() -> None:
+    usage = SimpleNamespace(total_tokens=10)
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="final answer",
+                    reasoning="private reasoning",
+                )
+            )
+        ],
+        usage=usage,
+    )
+    sampler = _sampler_with_response(response)
+    messages = [{"role": "user", "content": "question"}]
+
+    result = sampler(messages.copy())
+
+    assert result.response_text == "final answer"
+    assert result.actual_queried_message_list == messages
+    assert result.response_metadata == {
+        "usage": usage,
+        "reasoning": "private reasoning",
+    }
+
+
+def test_missing_reasoning_does_not_add_metadata_field() -> None:
+    usage = SimpleNamespace(total_tokens=10)
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="final answer"))],
+        usage=usage,
+    )
+    sampler = _sampler_with_response(response)
+
+    result = sampler([{"role": "user", "content": "question"}])
+
+    assert result.response_metadata == {"usage": usage}


### PR DESCRIPTION
## Summary

Keep model-generated Chat Completions reasoning separate from the message list reported as the prompt actually queried.

`ChatCompletionsSampler` currently appends `choice.message.reasoning` to `message_list` after the API returns, then exposes that mutated list as `actual_queried_message_list`. HealthBench uses that field as the conversation passed to its grader before adding the final response, so reasoning can become an extra assistant turn that affects grading even though it was not part of the original prompt.

Fixes #264.

## Fix

The sampler now:

- leaves `actual_queried_message_list` equal to the messages sent to the API;
- keeps final answer content in `response_text` as before;
- retains a non-empty `reasoning` field separately in `response_metadata` for diagnostics.

## Regression coverage

Adds tests verifying that:

- a response containing reasoning does not mutate the queried prompt history;
- final content remains the sampled response;
- reasoning is retained in metadata;
- responses without reasoning preserve the existing metadata shape apart from usage.

The request payload, scoring logic, retry behavior, and final response extraction are unchanged.