### PR TITLE
Preserve unlimited token sentinel in text generation CLI

### DIFF
--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -28,8 +28,7 @@ def main(args):
 
     tokenizer = get_tokenizer()
     tokens = tokenizer.encode(args.prompt)
-    max_tokens = None if args.limit == 0 else args.limit
-    for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=max_tokens, return_logprobs=True):
+    for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=args.limit, return_logprobs=True):
         tokens.append(token)
         token_text = tokenizer.decode([token])
         print(

--- a/tests/gpt_oss/test_generate.py
+++ b/tests/gpt_oss/test_generate.py
@@ -1,0 +1,56 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import gpt_oss.generate as generate_module
+
+
+class StubTokenizer:
+    eot_token = 999
+
+    def encode(self, prompt: str) -> list[int]:
+        return [1]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "x"
+
+
+def test_generate_passes_zero_limit_to_backend(monkeypatch) -> None:
+    captured = {}
+
+    class StubGenerator:
+        def __init__(self, checkpoint, device):
+            captured["checkpoint"] = checkpoint
+            captured["device"] = device
+
+        def generate(
+            self,
+            prompt_tokens,
+            stop_tokens,
+            temperature,
+            max_tokens,
+            return_logprobs,
+        ):
+            captured["max_tokens"] = max_tokens
+            yield 7, -0.1
+
+    fake_utils = ModuleType("gpt_oss.torch.utils")
+    fake_utils.init_distributed = lambda: "device"
+    fake_model = ModuleType("gpt_oss.torch.model")
+    fake_model.TokenGenerator = StubGenerator
+    monkeypatch.setitem(sys.modules, "gpt_oss.torch.utils", fake_utils)
+    monkeypatch.setitem(sys.modules, "gpt_oss.torch.model", fake_model)
+    monkeypatch.setattr(generate_module, "get_tokenizer", lambda: StubTokenizer())
+
+    args = SimpleNamespace(
+        backend="torch",
+        checkpoint="checkpoint",
+        context_length=4096,
+        tensor_parallel_size=1,
+        prompt="hello",
+        temperature=0.0,
+        limit=0,
+    )
+
+    generate_module.main(args)
+
+    assert captured["max_tokens"] == 0


### PR DESCRIPTION
## Summary

Pass the generation CLI's documented unlimited-token sentinel to the selected backend unchanged.

`--limit 0` is the default and is documented as disabling the token limit, but `gpt_oss.generate` currently converts 0 to `None`. The Torch and Triton generators implement unlimited generation with integer `0` and compare `num_generated_tokens < max_tokens`, so `None` can cause a `TypeError`. The vLLM generator also accepts 0 and converts it internally for vLLM.

Fixes #268.

## Fix

Pass `args.limit` directly as `max_tokens`.

## Regression coverage

Adds a backend-stub test around `main()` verifying that the default/unlimited `limit=0` reaches the token generator as integer 0 without requiring a checkpoint, GPU, or inference dependency.

Finite positive limits, stop tokens, temperature, logprob behavior, and backend selection are unchanged.