### PR TITLE
Allocate Responses Triton KV caches on the model device

### DIFF
--- a/gpt_oss/responses_api/inference/triton.py
+++ b/gpt_oss/responses_api/inference/triton.py
@@ -33,7 +33,12 @@ def load_model(checkpoint: str):
 
 def get_infer_next_token(model, device):
     caches = [
-        Cache(CONCURRENT_SESSIONS, CONTEXT, model.config.num_key_value_heads)
+        Cache(
+            CONCURRENT_SESSIONS,
+            CONTEXT,
+            model.config.num_key_value_heads,
+            device=device,
+        )
         for _ in range(len(model.block))
     ]
     # offsets = torch.zeros(CONCURRENT_SESSIONS, dtype=torch.int32, device=device) # TBD

--- a/tests/gpt_oss/responses_api/inference/test_triton_cache_device.py
+++ b/tests/gpt_oss/responses_api/inference/test_triton_cache_device.py
@@ -1,0 +1,47 @@
+import contextlib
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_get_infer_next_token_places_all_caches_on_model_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = pytest.importorskip("torch")
+
+    created_devices = []
+
+    class FakeCache:
+        def __init__(self, batch_size, n_ctx, n_kv_heads, d_head=64, device=None):
+            created_devices.append(device)
+
+    fake_model_module = ModuleType("gpt_oss.triton.model")
+    fake_model_module.Cache = FakeCache
+    fake_model_module.ModelConfig = object
+    fake_model_module.Transformer = object
+    monkeypatch.setitem(sys.modules, "gpt_oss.triton.model", fake_model_module)
+    sys.modules.pop("gpt_oss.responses_api.inference.triton", None)
+
+    triton_backend = importlib.import_module("gpt_oss.responses_api.inference.triton")
+
+    tensor = MagicMock()
+    monkeypatch.setattr(triton_backend.torch, "zeros", MagicMock(return_value=tensor))
+    monkeypatch.setattr(triton_backend.torch.cuda, "CUDAGraph", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        triton_backend.torch.cuda,
+        "graph",
+        lambda graph: contextlib.nullcontext(),
+    )
+
+    model = MagicMock()
+    model.config.num_key_value_heads = 8
+    model.block = [object(), object(), object()]
+    model.return_value = [MagicMock()]
+    device = torch.device("cuda:1")
+
+    triton_backend.get_infer_next_token(model, device)
+
+    assert created_devices == [device, device, device]


### PR DESCRIPTION
## Summary

Allocate the Responses API Triton backend's KV caches on the same device as the model and token tensors.

`get_infer_next_token()` currently constructs `Cache` objects without a device argument. `Cache` defaults to `device=None`, so its key/value tensors are created on CPU while the Triton model, warmup input, and subsequent key/value tensors run on CUDA.

Fixes #271.

## Fix

Pass `device=device` to every per-layer `Cache` constructor.

## Regression coverage

Adds a mocked backend-construction test that avoids Triton compilation and GPU execution while verifying that every layer cache receives the model device.

The cache dimensions, context length, session count, warmup flow, model device, and inference logic are otherwise unchanged.