### PR TITLE
Use local rank for Responses Triton CUDA binding

### DIFF
--- a/gpt_oss/responses_api/inference/triton.py
+++ b/gpt_oss/responses_api/inference/triton.py
@@ -14,15 +14,16 @@ CONCURRENT_SESSIONS = 1
 
 rank = int(
     os.environ.get("RANK", 0)
-)  # set this env var to another value to run on other GPUs
+)  # global distributed rank
+local_rank = int(os.environ.get("LOCAL_RANK", rank))
 
 
 def load_model(checkpoint: str):
     print(f"[{rank}] loading model...")
 
-    torch.cuda.set_device(rank)
+    torch.cuda.set_device(local_rank)
     torch.set_grad_enabled(False)
-    device = torch.device(f"cuda:{rank}")
+    device = torch.device(f"cuda:{local_rank}")
 
     # Load model
     model = Transformer.from_checkpoint(checkpoint, device=device)

--- a/tests/gpt_oss/responses_api/inference/test_triton_local_rank.py
+++ b/tests/gpt_oss/responses_api/inference/test_triton_local_rank.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_load_model_uses_local_rank_for_cuda_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = pytest.importorskip("torch")
+    monkeypatch.setenv("RANK", "5")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+
+    loaded = {}
+    fake_model = object()
+
+    class FakeTransformer:
+        @staticmethod
+        def from_checkpoint(checkpoint, device):
+            loaded["checkpoint"] = checkpoint
+            loaded["device"] = device
+            return fake_model
+
+    fake_model_module = ModuleType("gpt_oss.triton.model")
+    fake_model_module.Cache = object
+    fake_model_module.ModelConfig = object
+    fake_model_module.Transformer = FakeTransformer
+    monkeypatch.setitem(sys.modules, "gpt_oss.triton.model", fake_model_module)
+    sys.modules.pop("gpt_oss.responses_api.inference.triton", None)
+
+    triton_backend = importlib.import_module("gpt_oss.responses_api.inference.triton")
+    set_device = MagicMock()
+    monkeypatch.setattr(triton_backend.torch.cuda, "set_device", set_device)
+    monkeypatch.setattr(triton_backend.torch, "set_grad_enabled", MagicMock())
+
+    model, device = triton_backend.load_model("checkpoint")
+
+    assert model is fake_model
+    assert device == torch.device("cuda:1")
+    assert loaded == {"checkpoint": "checkpoint", "device": torch.device("cuda:1")}
+    assert triton_backend.rank == 5
+    assert triton_backend.local_rank == 1
+    set_device.assert_called_once_with(1)

--- a/tests/gpt_oss/responses_api/inference/test_triton_local_rank.py
+++ b/tests/gpt_oss/responses_api/inference/test_triton_local_rank.py
@@ -28,7 +28,9 @@ def test_load_model_uses_local_rank_for_cuda_device(
     fake_model_module.ModelConfig = object
     fake_model_module.Transformer = FakeTransformer
     monkeypatch.setitem(sys.modules, "gpt_oss.triton.model", fake_model_module)
-    sys.modules.pop("gpt_oss.responses_api.inference.triton", None)
+    monkeypatch.delitem(
+        sys.modules, "gpt_oss.responses_api.inference.triton", raising=False
+    )
 
     triton_backend = importlib.import_module("gpt_oss.responses_api.inference.triton")
     set_device = MagicMock()


### PR DESCRIPTION
## Summary

Bind the Responses API Triton backend to its node-local CUDA device instead of using global distributed rank as a device index.

This backend selects its device independently and does not call `gpt_oss.torch.utils.init_distributed()`, so the local-rank correction in #267 does not cover it.

Fixes #273.

## Fix

- keep global `RANK` for distributed identity and log prefixes;
- use `LOCAL_RANK` for `torch.cuda.set_device()` and the CUDA device object;
- fall back to global `RANK` when `LOCAL_RANK` is absent, preserving existing single-node/custom-launch behavior.

## Regression coverage

Adds a CPU-only mocked regression with `RANK=5` and `LOCAL_RANK=1` verifying that:

- global rank remains 5;
- local rank is 1;
- model loading receives `cuda:1`;
- CUDA binding uses device index 1.

No model loading, checkpoint format, inference math, or logging identity is otherwise changed.