### PR TITLE
Expand Responses API checkpoint paths before backend setup

### DIFF
--- a/gpt_oss/responses_api/serve.py
+++ b/gpt_oss/responses_api/serve.py
@@ -1,6 +1,7 @@
 # torchrun --nproc-per-node=4 serve.py
 
 import argparse
+import os
 
 import uvicorn
 from openai_harmony import (
@@ -9,6 +10,11 @@ from openai_harmony import (
 )
 
 from .api_server import create_api_server
+
+
+def resolve_checkpoint_path(checkpoint: str) -> str:
+    return os.path.expanduser(checkpoint)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Responses API server")
@@ -54,5 +60,5 @@ if __name__ == "__main__":
 
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
-    infer_next_token = setup_model(args.checkpoint)
+    infer_next_token = setup_model(resolve_checkpoint_path(args.checkpoint))
     uvicorn.run(create_api_server(infer_next_token, encoding), port=args.port)

--- a/tests/gpt_oss/responses_api/test_serve_checkpoint_path.py
+++ b/tests/gpt_oss/responses_api/test_serve_checkpoint_path.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from gpt_oss.responses_api.serve import resolve_checkpoint_path
+
+
+def test_resolve_checkpoint_path_expands_user_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert resolve_checkpoint_path("~/model") == str(tmp_path / "model")
+
+
+def test_resolve_checkpoint_path_preserves_absolute_path(tmp_path: Path) -> None:
+    checkpoint = str(tmp_path / "model")
+
+    assert resolve_checkpoint_path(checkpoint) == checkpoint


### PR DESCRIPTION
## Summary

Make the Responses API launcher's default `~/model` checkpoint resolve to the user's home directory before it reaches any inference backend.

The launcher currently forwards the literal `~` path. Python file APIs do not expand that automatically, and the Triton reference path eventually opens paths beneath the unresolved string.

Fixes #277.

## Fix

Add a small `resolve_checkpoint_path()` helper using `os.path.expanduser()` and apply it once at the backend setup boundary.

## Regression coverage

Adds tests verifying that:

- `~/model` resolves under a controlled home directory;
- an already absolute checkpoint path is preserved unchanged.

Backend selection, checkpoint contents, port configuration, and model setup behavior are otherwise unchanged.