### PR TITLE
Reset Responses stub output for each new request

### DIFF
--- a/gpt_oss/responses_api/inference/stub.py
+++ b/gpt_oss/responses_api/inference/stub.py
@@ -131,6 +131,8 @@ def stub_infer_next_token(
     tokens: list[int], temperature: float = 0.0, new_request: bool = False
 ) -> int:
     global token_queue
+    if new_request:
+        token_queue = fake_tokens.copy()
     next_tok = token_queue.pop(0)
     if len(token_queue) == 0:
         token_queue = fake_tokens.copy()

--- a/tests/gpt_oss/responses_api/inference/test_stub_request_reset.py
+++ b/tests/gpt_oss/responses_api/inference/test_stub_request_reset.py
@@ -1,0 +1,14 @@
+import gpt_oss.responses_api.inference.stub as stub_backend
+
+
+def test_new_request_restarts_fake_token_sequence(monkeypatch) -> None:
+    monkeypatch.setattr(stub_backend.time, "sleep", lambda delay: None)
+    stub_backend.token_queue = stub_backend.fake_tokens.copy()
+
+    first = stub_backend.stub_infer_next_token([], new_request=False)
+    second = stub_backend.stub_infer_next_token([], new_request=False)
+    restarted = stub_backend.stub_infer_next_token([], new_request=True)
+
+    assert first == stub_backend.fake_tokens[0]
+    assert second == stub_backend.fake_tokens[1]
+    assert restarted == stub_backend.fake_tokens[0]

--- a/tests/gpt_oss/responses_api/inference/test_stub_request_reset.py
+++ b/tests/gpt_oss/responses_api/inference/test_stub_request_reset.py
@@ -3,7 +3,7 @@ import gpt_oss.responses_api.inference.stub as stub_backend
 
 def test_new_request_restarts_fake_token_sequence(monkeypatch) -> None:
     monkeypatch.setattr(stub_backend.time, "sleep", lambda delay: None)
-    stub_backend.token_queue = stub_backend.fake_tokens.copy()
+    monkeypatch.setattr(stub_backend, "token_queue", stub_backend.fake_tokens.copy())
 
     first = stub_backend.stub_infer_next_token([], new_request=False)
     second = stub_backend.stub_infer_next_token([], new_request=False)


### PR DESCRIPTION
## Summary

Make the Responses API stub backend restart its deterministic fake-token sequence for every new API request.

The stub accepts the standard `new_request` flag but currently ignores it, while its token position lives in the module-global `token_queue`. A second request therefore starts wherever the previous request stopped rather than from the beginning of the stub response.

Fixes #281.

## Fix

Reset `token_queue` to `fake_tokens.copy()` when `new_request=True` before returning the first token.

## Regression coverage

Adds a deterministic test that:

- consumes the first two fake tokens;
- starts a new request;
- verifies the next token is again `fake_tokens[0]`.

The fake response content, automatic wraparound behavior, setup interface, and simulated latency are otherwise unchanged.