### PR TITLE
Normalize nullable Responses request fields before server use

### DIFF
--- a/gpt_oss/responses_api/types.py
+++ b/gpt_oss/responses_api/types.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Literal, Optional, Union
 
 from openai_harmony import ReasoningEffort
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 MODEL_IDENTIFIER = "gpt-oss-120b"
 DEFAULT_TEMPERATURE = 0.0
@@ -139,7 +139,7 @@ class FunctionToolDefinition(BaseModel):
 
 
 class BrowserToolConfig(BaseModel):
-    model_config = ConfigDict(extra='allow')
+    model_config = ConfigDict(extra="allow")
     type: Literal["browser_search"] | Literal["web_search"]
 
 
@@ -182,6 +182,21 @@ class ResponsesRequest(BaseModel):
     previous_response_id: Optional[str] = None
     temperature: Optional[float] = DEFAULT_TEMPERATURE
     include: Optional[list[str]] = None
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def normalize_metadata(cls, value):
+        return {} if value is None else value
+
+    @field_validator("tools", mode="before")
+    @classmethod
+    def normalize_tools(cls, value):
+        return [] if value is None else value
+
+    @field_validator("max_output_tokens", mode="before")
+    @classmethod
+    def normalize_max_output_tokens(cls, value):
+        return DEFAULT_MAX_OUTPUT_TOKENS if value is None else value
 
 
 class ResponseObject(BaseModel):

--- a/tests/gpt_oss/responses_api/test_nullable_request_fields.py
+++ b/tests/gpt_oss/responses_api/test_nullable_request_fields.py
@@ -1,0 +1,27 @@
+from gpt_oss.responses_api.types import DEFAULT_MAX_OUTPUT_TOKENS, ResponsesRequest
+
+
+def test_explicit_null_server_fields_use_concrete_defaults() -> None:
+    request = ResponsesRequest(
+        input="hello",
+        metadata=None,
+        tools=None,
+        max_output_tokens=None,
+    )
+
+    assert request.metadata == {}
+    assert request.tools == []
+    assert request.max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_non_null_server_fields_are_preserved() -> None:
+    request = ResponsesRequest(
+        input="hello",
+        metadata={"key": "value"},
+        tools=[],
+        max_output_tokens=32,
+    )
+
+    assert request.metadata == {"key": "value"}
+    assert request.tools == []
+    assert request.max_output_tokens == 32


### PR DESCRIPTION
## Summary

Normalize nullable Responses request fields at the Pydantic model boundary so values accepted by the request schema do not fail later in the local server.

`metadata`, `tools`, and `max_output_tokens` are declared optional. Explicit JSON `null` therefore validates, but the server subsequently calls `.get()` on metadata, iterates tools when instructions are present, and numerically compares the output-token limit.

Fixes #283.

## Fix

Field validators map explicit `None` values to the concrete defaults already assumed by the server:

- `metadata=None` -> `{}`
- `tools=None` -> `[]`
- `max_output_tokens=None` -> `DEFAULT_MAX_OUTPUT_TOKENS`

Non-null caller values are preserved unchanged.

## Regression coverage

Adds direct request-model tests for all three nullable fields and verifies non-null values remain intact.

No API-server control flow, inference behavior, or non-null request semantics are changed.