### PR TITLE
Synchronize distributed token sampling across model-parallel ranks

### DIFF
--- a/gpt_oss/torch/model.py
+++ b/gpt_oss/torch/model.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import torch
 import torch.distributed as dist
 
+from gpt_oss.torch.sampling import sample_next_token
 from gpt_oss.torch.weights import Checkpoint
 
 
@@ -458,11 +459,7 @@ class TokenGenerator:
         num_generated_tokens = 0
         while max_tokens == 0 or num_generated_tokens < max_tokens:
             logits = self.model(torch.as_tensor(tokens, dtype=torch.int32, device=self.device))[-1]
-            if temperature == 0.0:
-                predicted_token = torch.argmax(logits, dim=-1).item()
-            else:
-                probs = torch.softmax(logits * (1.0 / temperature), dim=-1)
-                predicted_token = torch.multinomial(probs, num_samples=1).item()
+            predicted_token = sample_next_token(logits, temperature)
             tokens.append(predicted_token)
             num_generated_tokens += 1
 

--- a/gpt_oss/torch/sampling.py
+++ b/gpt_oss/torch/sampling.py
@@ -1,0 +1,22 @@
+import torch
+import torch.distributed as dist
+
+
+def sample_next_token(logits: torch.Tensor, temperature: float) -> int:
+    """Sample one token and keep model-parallel ranks on the same token history."""
+    distributed = dist.is_initialized()
+    rank = dist.get_rank() if distributed else 0
+
+    if rank == 0:
+        if temperature == 0.0:
+            token = torch.argmax(logits, dim=-1).to(torch.long)
+        else:
+            probs = torch.softmax(logits * (1.0 / temperature), dim=-1)
+            token = torch.multinomial(probs, num_samples=1).squeeze(0)
+    else:
+        token = torch.empty((), dtype=torch.long, device=logits.device)
+
+    if distributed:
+        dist.broadcast(token, src=0)
+
+    return int(token.item())

--- a/gpt_oss/triton/model.py
+++ b/gpt_oss/triton/model.py
@@ -6,6 +6,7 @@ import torch
 from torch.profiler import record_function
 
 from gpt_oss.torch.model import ModelConfig, RMSNorm
+from gpt_oss.torch.sampling import sample_next_token
 from gpt_oss.torch.weights import Checkpoint
 from gpt_oss.triton.attention import attention, attention_ref
 from gpt_oss.triton.moe import quantize_mx4, moe
@@ -498,11 +499,7 @@ class TokenGenerator:
         while max_tokens == 0 or num_generated_tokens < max_tokens:
             self.input_token[0] = predicted_token
             self.graph.replay()
-            if temperature == 0.0:
-                predicted_token = torch.argmax(self.logits[-1, :], dim=-1).item()
-            else:
-                probs = torch.softmax(self.logits * (1.0 / temperature), dim=-1)
-                predicted_token = torch.multinomial(probs[-1, :], num_samples=1).item()
+            predicted_token = sample_next_token(self.logits[-1, :], temperature)
             num_generated_tokens += 1
 
             if return_logprobs:

--- a/tests/gpt_oss/torch/test_sampling.py
+++ b/tests/gpt_oss/torch/test_sampling.py
@@ -1,0 +1,53 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gpt_oss.torch import sampling
+
+
+def test_local_greedy_sampling_is_unchanged(monkeypatch) -> None:
+    monkeypatch.setattr(sampling.dist, "is_initialized", lambda: False)
+
+    token = sampling.sample_next_token(torch.tensor([0.1, 0.8, 0.2]), 0.0)
+
+    assert token == 1
+
+
+def test_rank_zero_samples_and_broadcasts(monkeypatch) -> None:
+    broadcasts = []
+    monkeypatch.setattr(sampling.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(sampling.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(
+        sampling.torch,
+        "multinomial",
+        lambda probs, num_samples: torch.tensor([2], device=probs.device),
+    )
+    monkeypatch.setattr(
+        sampling.dist,
+        "broadcast",
+        lambda tensor, src: broadcasts.append((int(tensor.item()), src)),
+    )
+
+    token = sampling.sample_next_token(torch.tensor([0.2, 0.3, 0.5]), 1.0)
+
+    assert token == 2
+    assert broadcasts == [(2, 0)]
+
+
+def test_nonzero_rank_uses_broadcast_token_without_sampling(monkeypatch) -> None:
+    monkeypatch.setattr(sampling.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(sampling.dist, "get_rank", lambda: 1)
+
+    def fail_if_sampled(*args, **kwargs):
+        raise AssertionError("nonzero ranks must not sample independently")
+
+    def receive_rank_zero_token(tensor, src):
+        assert src == 0
+        tensor.fill_(1)
+
+    monkeypatch.setattr(sampling.torch, "multinomial", fail_if_sampled)
+    monkeypatch.setattr(sampling.dist, "broadcast", receive_rank_zero_token)
+
+    token = sampling.sample_next_token(torch.tensor([0.9, 0.1]), 1.0)
+
+    assert token == 1


### PR DESCRIPTION
## Summary

Keep stochastic generation on the same token history across model-parallel ranks.

The Torch and Triton reference generators currently call `torch.multinomial()` independently on every distributed rank. With nonzero temperature, ranks can sample different tokens and then feed different token histories into later model-parallel collectives.

Fixes #270.

## Fix

Add one shared sampling helper used by both reference backends:

- in single-process mode, preserve the existing greedy and stochastic sampling behavior;
- when `torch.distributed` is initialized, sample/select the next token only on rank 0;
- broadcast that token to every rank before continuing generation.

Both the Torch and Triton generators now use the same synchronized path.

## Regression coverage

Adds CPU-only mocked tests verifying that:

- local greedy sampling is unchanged;
- rank 0 samples and broadcasts its token;
- a nonzero rank does not call `torch.multinomial()` and instead consumes the token received from rank 0.

Model logits, temperature scaling, stop-token handling, log-probability reporting, and single-process generation semantics are otherwise unchanged.