### PR TITLE
Keep Harmony special token IDs unique

### DIFF
--- a/gpt_oss/tokenizer.py
+++ b/gpt_oss/tokenizer.py
@@ -1,30 +1,37 @@
 import tiktoken
 
+
 def get_tokenizer():
     o200k_base = tiktoken.get_encoding("o200k_base")
+    special_tokens = {
+        **o200k_base._special_tokens,
+        "<|startoftext|>": 199998,
+        "<|endoftext|>": 199999,
+        "<|reserved_200000|>": 200000,
+        "<|reserved_200001|>": 200001,
+        "<|return|>": 200002,
+        "<|constrain|>": 200003,
+        "<|reserved_200004|>": 200004,
+        "<|channel|>": 200005,
+        "<|start|>": 200006,
+        "<|end|>": 200007,
+        "<|message|>": 200008,
+        "<|reserved_200009|>": 200009,
+        "<|reserved_200010|>": 200010,
+        "<|reserved_200011|>": 200011,
+        "<|call|>": 200012,
+    }
+    used_token_ids = set(special_tokens.values())
+    special_tokens |= {
+        f"<|reserved_{i}|>": i
+        for i in range(200013, 201088)
+        if i not in used_token_ids
+    }
+
     tokenizer = tiktoken.Encoding(
         name="o200k_harmony",
         pat_str=o200k_base._pat_str,
         mergeable_ranks=o200k_base._mergeable_ranks,
-        special_tokens={
-            **o200k_base._special_tokens,
-            "<|startoftext|>": 199998,
-            "<|endoftext|>": 199999,
-            "<|reserved_200000|>": 200000,
-            "<|reserved_200001|>": 200001,
-            "<|return|>": 200002,
-            "<|constrain|>": 200003,
-            "<|reserved_200004|>": 200004,
-            "<|channel|>": 200005,
-            "<|start|>": 200006,
-            "<|end|>": 200007,
-            "<|message|>": 200008,
-            "<|reserved_200009|>": 200009,
-            "<|reserved_200010|>": 200010,
-            "<|reserved_200011|>": 200011,
-            "<|call|>": 200012,
-        } | {
-            f"<|reserved_{i}|>": i for i in range(200013, 201088)
-        },
+        special_tokens=special_tokens,
     )
     return tokenizer

--- a/tests/gpt_oss/test_tokenizer.py
+++ b/tests/gpt_oss/test_tokenizer.py
@@ -1,0 +1,15 @@
+from gpt_oss.tokenizer import get_tokenizer
+
+
+def test_harmony_special_token_ids_are_unique() -> None:
+    tokenizer = get_tokenizer()
+    special_tokens = tokenizer._special_tokens
+
+    assert len(special_tokens.values()) == len(set(special_tokens.values()))
+
+
+def test_endofprompt_keeps_its_base_token_id_without_reserved_alias() -> None:
+    tokenizer = get_tokenizer()
+
+    assert tokenizer._special_tokens["<|endofprompt|>"] == 200018
+    assert "<|reserved_200018|>" not in tokenizer._special_tokens


### PR DESCRIPTION
## Summary

Remove the duplicate special-token ID in the repository's local Harmony tokenizer.

`get_tokenizer()` copies `o200k_base._special_tokens`, where `<|endofprompt|>` already uses ID 200018, and then generates every `reserved_*` entry from 200013 through 201087. That also creates `<|reserved_200018|>` with the same ID.

Fixes #286.

## Fix

Build the explicit/base special-token map first, collect its occupied IDs, and generate reserved entries only for IDs that are still unused. `<|endofprompt|>` therefore remains at 200018 without a reserved alias.

## Regression coverage

Adds tests verifying that:

- every Harmony special-token ID is unique;
- `<|endofprompt|>` remains mapped to 200018;
- `<|reserved_200018|>` is not generated.

Mergeable ranks, all other Harmony token IDs, and tokenizer construction are unchanged.