### PR TITLE
Handle empty eval sample sets without creating a zero-worker pool

### DIFF
--- a/gpt_oss/evals/report.py
+++ b/gpt_oss/evals/report.py
@@ -88,6 +88,9 @@ def map_with_progress(
     """
     Apply f to each element of xs, using a ThreadPool, and show progress.
     """
+    if not xs:
+        return []
+
     pbar_fn = tqdm if pbar else lambda x, *args, **kwargs: x
 
     if os.getenv("debug"):

--- a/tests/gpt_oss/evals/test_report.py
+++ b/tests/gpt_oss/evals/test_report.py
@@ -1,0 +1,17 @@
+from gpt_oss.evals.report import map_with_progress
+
+
+def test_empty_input_returns_without_calling_mapper() -> None:
+    called = False
+
+    def fail_if_called(_):
+        nonlocal called
+        called = True
+        raise AssertionError("mapper must not run for an empty sample set")
+
+    assert map_with_progress(fail_if_called, [], pbar=True) == []
+    assert called is False
+
+
+def test_empty_input_without_progress_returns_empty() -> None:
+    assert map_with_progress(lambda value: value, [], pbar=False) == []


### PR DESCRIPTION
## Summary

Make the eval progress helper handle an empty sample list directly.

`map_with_progress()` currently constructs `ThreadPool(min(num_threads, len(xs)))`. For `xs=[]`, that becomes `ThreadPool(0)` and raises before an empty eval can return normally.

Fixes #288.

## Fix

Return `[]` immediately for an empty input list, before selecting the progress wrapper or creating workers.

## Regression coverage

Adds focused tests verifying that empty inputs:

- return an empty result with progress enabled;
- return an empty result with progress disabled;
- never invoke the mapped function.

Non-empty threaded/debug execution and result ordering behavior are unchanged.