### PR TITLE
Synchronize distributed generation and execute chat tools on rank zero

### DIFF
--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -58,6 +58,35 @@ def get_user_input():
     return user_input_list[0]
 
 
+def _run_tool_on_rank_zero(run_tool):
+    if not torch.distributed.is_initialized():
+        return run_tool()
+
+    payload = None
+    if torch.distributed.get_rank() == 0:
+        try:
+            result = run_tool()
+            payload = {
+                "messages": [message.to_dict() for message in result],
+                "error": None,
+            }
+        except Exception as exc:
+            payload = {
+                "messages": [],
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+    payload_list = [payload]
+    torch.distributed.broadcast_object_list(payload_list, 0)
+    payload = payload_list[0]
+    assert payload is not None
+
+    if payload["error"] is not None:
+        raise RuntimeError(f"Tool execution failed on rank 0: {payload['error']}")
+
+    return [Message.from_dict(message) for message in payload["messages"]]
+
+
 def main(args):
     match args.backend:
         case "triton":
@@ -177,7 +206,7 @@ def main(args):
                         results.append(msg)
                     return results
 
-                result = asyncio.run(run_tool())
+                result = _run_tool_on_rank_zero(lambda: asyncio.run(run_tool()))
                 messages += result
             elif last_message.recipient.startswith("python"):
                 assert args.python, "Python tool is not enabled"
@@ -188,40 +217,43 @@ def main(args):
                         results.append(msg)
                     return results
 
-                result = asyncio.run(run_tool())
+                result = _run_tool_on_rank_zero(lambda: asyncio.run(run_tool()))
                 messages += result
             elif last_message.recipient == "functions.apply_patch":
                 assert args.apply_patch, "Apply patch tool is not enabled"
                 tool_name = "Apply Patch"
-                text = last_message.content[0].text
-                tool_output = None
 
-                if text.startswith("{"):
-                    # this is json, try to extract the patch from it
-                    import json
-                    try:
-                        some_dict = json.loads(text)
-                        _, text = some_dict.popitem()
-                    except Exception as e:
-                        tool_output = f"Error parsing JSON: {e}"
+                def run_tool():
+                    text = last_message.content[0].text
+                    tool_output = None
 
-                if tool_output is None:
-                    try:
-                        tool_output = apply_patch.apply_patch(text)
-                    except Exception as e:
-                        tool_output = f"Error applying patch: {e}"
+                    if text.startswith("{"):
+                        # this is json, try to extract the patch from it
+                        import json
+                        try:
+                            some_dict = json.loads(text)
+                            _, text = some_dict.popitem()
+                        except Exception as e:
+                            tool_output = f"Error parsing JSON: {e}"
 
-                message = (
-                    Message(
-                        author=Author.new(Role.TOOL, last_message.recipient),
-                        content=[TextContent(text=tool_output)]
+                    if tool_output is None:
+                        try:
+                            tool_output = apply_patch.apply_patch(text)
+                        except Exception as e:
+                            tool_output = f"Error applying patch: {e}"
+
+                    message = (
+                        Message(
+                            author=Author.new(Role.TOOL, last_message.recipient),
+                            content=[TextContent(text=tool_output)]
+                        )
+                        .with_recipient("assistant")
                     )
-                    .with_recipient("assistant")
-                )
-                if last_message.channel:
-                    message = message.with_channel(last_message.channel)
+                    if last_message.channel:
+                        message = message.with_channel(last_message.channel)
+                    return [message]
 
-                result = [message]
+                result = _run_tool_on_rank_zero(run_tool)
                 messages += result
             else:
                 raise ValueError(f"Unknown tool or function call: {last_message.recipient}")

--- a/gpt_oss/torch/model.py
+++ b/gpt_oss/torch/model.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import torch
 import torch.distributed as dist
 
+from gpt_oss.torch.sampling import sample_next_token
 from gpt_oss.torch.weights import Checkpoint
 
 
@@ -458,11 +459,7 @@ class TokenGenerator:
         num_generated_tokens = 0
         while max_tokens == 0 or num_generated_tokens < max_tokens:
             logits = self.model(torch.as_tensor(tokens, dtype=torch.int32, device=self.device))[-1]
-            if temperature == 0.0:
-                predicted_token = torch.argmax(logits, dim=-1).item()
-            else:
-                probs = torch.softmax(logits * (1.0 / temperature), dim=-1)
-                predicted_token = torch.multinomial(probs, num_samples=1).item()
+            predicted_token = sample_next_token(logits, temperature)
             tokens.append(predicted_token)
             num_generated_tokens += 1
 

--- a/gpt_oss/torch/sampling.py
+++ b/gpt_oss/torch/sampling.py
@@ -1,0 +1,22 @@
+import torch
+import torch.distributed as dist
+
+
+def sample_next_token(logits: torch.Tensor, temperature: float) -> int:
+    """Sample one token and keep model-parallel ranks on the same token history."""
+    distributed = dist.is_initialized()
+    rank = dist.get_rank() if distributed else 0
+
+    if rank == 0:
+        if temperature == 0.0:
+            token = torch.argmax(logits, dim=-1).to(torch.long)
+        else:
+            probs = torch.softmax(logits * (1.0 / temperature), dim=-1)
+            token = torch.multinomial(probs, num_samples=1).squeeze(0)
+    else:
+        token = torch.empty((), dtype=torch.long, device=logits.device)
+
+    if distributed:
+        dist.broadcast(token, src=0)
+
+    return int(token.item())

--- a/gpt_oss/triton/model.py
+++ b/gpt_oss/triton/model.py
@@ -6,6 +6,7 @@ import torch
 from torch.profiler import record_function
 
 from gpt_oss.torch.model import ModelConfig, RMSNorm
+from gpt_oss.torch.sampling import sample_next_token
 from gpt_oss.torch.weights import Checkpoint
 from gpt_oss.triton.attention import attention, attention_ref
 from gpt_oss.triton.moe import quantize_mx4, moe
@@ -498,11 +499,7 @@ class TokenGenerator:
         while max_tokens == 0 or num_generated_tokens < max_tokens:
             self.input_token[0] = predicted_token
             self.graph.replay()
-            if temperature == 0.0:
-                predicted_token = torch.argmax(self.logits[-1, :], dim=-1).item()
-            else:
-                probs = torch.softmax(self.logits * (1.0 / temperature), dim=-1)
-                predicted_token = torch.multinomial(probs[-1, :], num_samples=1).item()
+            predicted_token = sample_next_token(self.logits[-1, :], temperature)
             num_generated_tokens += 1
 
             if return_logprobs:

--- a/tests/gpt_oss/test_chat_distributed.py
+++ b/tests/gpt_oss/test_chat_distributed.py
@@ -1,0 +1,44 @@
+import pytest
+from openai_harmony import Message, Role
+
+from gpt_oss import chat
+
+
+def test_local_tool_execution_is_unchanged(monkeypatch) -> None:
+    monkeypatch.setattr(chat.torch.distributed, "is_initialized", lambda: False)
+    expected = [Message.from_role_and_content(Role.TOOL, "local")]
+
+    assert chat._run_tool_on_rank_zero(lambda: expected) is expected
+
+
+def test_nonzero_rank_receives_rank_zero_tool_result(monkeypatch) -> None:
+    expected = Message.from_role_and_content(Role.TOOL, "from rank zero")
+    monkeypatch.setattr(chat.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(chat.torch.distributed, "get_rank", lambda: 1)
+
+    def broadcast(payload_list, src):
+        assert src == 0
+        payload_list[0] = {"messages": [expected.to_dict()], "error": None}
+
+    monkeypatch.setattr(chat.torch.distributed, "broadcast_object_list", broadcast)
+
+    def fail_if_executed():
+        raise AssertionError("nonzero ranks must not execute tools")
+
+    result = chat._run_tool_on_rank_zero(fail_if_executed)
+
+    assert [message.to_dict() for message in result] == [expected.to_dict()]
+
+
+def test_rank_zero_tool_failure_is_propagated(monkeypatch) -> None:
+    monkeypatch.setattr(chat.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(chat.torch.distributed, "get_rank", lambda: 1)
+
+    def broadcast(payload_list, src):
+        assert src == 0
+        payload_list[0] = {"messages": [], "error": "ValueError: broken tool"}
+
+    monkeypatch.setattr(chat.torch.distributed, "broadcast_object_list", broadcast)
+
+    with pytest.raises(RuntimeError, match="ValueError: broken tool"):
+        chat._run_tool_on_rank_zero(lambda: [])

--- a/tests/gpt_oss/torch/test_sampling.py
+++ b/tests/gpt_oss/torch/test_sampling.py
@@ -1,0 +1,53 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gpt_oss.torch import sampling
+
+
+def test_local_greedy_sampling_is_unchanged(monkeypatch) -> None:
+    monkeypatch.setattr(sampling.dist, "is_initialized", lambda: False)
+
+    token = sampling.sample_next_token(torch.tensor([0.1, 0.8, 0.2]), 0.0)
+
+    assert token == 1
+
+
+def test_rank_zero_samples_and_broadcasts(monkeypatch) -> None:
+    broadcasts = []
+    monkeypatch.setattr(sampling.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(sampling.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(
+        sampling.torch,
+        "multinomial",
+        lambda probs, num_samples: torch.tensor([2], device=probs.device),
+    )
+    monkeypatch.setattr(
+        sampling.dist,
+        "broadcast",
+        lambda tensor, src: broadcasts.append((int(tensor.item()), src)),
+    )
+
+    token = sampling.sample_next_token(torch.tensor([0.2, 0.3, 0.5]), 1.0)
+
+    assert token == 2
+    assert broadcasts == [(2, 0)]
+
+
+def test_nonzero_rank_uses_broadcast_token_without_sampling(monkeypatch) -> None:
+    monkeypatch.setattr(sampling.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(sampling.dist, "get_rank", lambda: 1)
+
+    def fail_if_sampled(*args, **kwargs):
+        raise AssertionError("nonzero ranks must not sample independently")
+
+    def receive_rank_zero_token(tensor, src):
+        assert src == 0
+        tensor.fill_(1)
+
+    monkeypatch.setattr(sampling.torch, "multinomial", fail_if_sampled)
+    monkeypatch.setattr(sampling.dist, "broadcast", receive_rank_zero_token)
+
+    token = sampling.sample_next_token(torch.tensor([0.9, 0.1]), 1.0)
+
+    assert token == 1


### PR DESCRIPTION
## Summary

Keep model-parallel chat ranks on one token history and execute external tool/function calls only once.

Two distributed paths were independently unsafe:

- Torch and Triton ranks sampled stochastic next tokens independently, so generated histories and assistant actions could diverge;
- browser, Python, and `apply_patch` calls executed independently on every rank, duplicating external side effects.

Fixes #270.
Fixes #290.

## Fix

- sample/select each next token on rank 0 and broadcast it to all ranks in both Torch and Triton reference generators;
- in single-process mode, preserve existing greedy and stochastic sampling behavior;
- execute browser, Python, and `apply_patch` callbacks only on rank 0;
- serialize Harmony tool-result `Message` objects with `to_dict()`, broadcast them, and reconstruct them with `Message.from_dict()` on every rank;
- broadcast rank-0 tool execution failures so peer ranks fail together rather than blocking.

## Regression coverage

Adds CPU-only mocked tests verifying that:

- local greedy sampling is unchanged;
- rank 0 samples and broadcasts its token;
- nonzero ranks never sample independently;
- local tool execution is unchanged;
- nonzero ranks never invoke tool callbacks and receive rank-0 messages;
- rank-0 tool failures propagate to peers.

Model logits, temperature scaling, stop-token handling, tool schemas, and non-distributed chat behavior are otherwise unchanged.