### PR TITLE
Honor explicit eval sample counts and repeat selection

### DIFF
--- a/gpt_oss/evals/__main__.py
+++ b/gpt_oss/evals/__main__.py
@@ -14,6 +14,14 @@ from .chat_completions_sampler import (
 from .responses_sampler import ResponsesSampler
 
 
+def _resolve_num_examples(
+    explicit_examples: int | None, debug_mode: bool, debug_default: int
+) -> int | None:
+    if explicit_examples is not None:
+        return explicit_examples
+    return debug_default if debug_mode else None
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Evaluate the models.",
@@ -95,9 +103,8 @@ def main():
     )
 
     def get_evals(eval_name, debug_mode):
-        num_examples = (
-            args.examples if args.examples is not None else (5 if debug_mode else None)
-        )
+        num_examples = _resolve_num_examples(args.examples, debug_mode, 5)
+        healthbench_num_examples = _resolve_num_examples(args.examples, debug_mode, 10)
         # Set num_examples = None to reproduce full evals
         match eval_name:
             case "basic":
@@ -112,7 +119,7 @@ def main():
             case "healthbench":
                 return HealthBenchEval(
                     grader_model=grading_sampler,
-                    num_examples=10 if debug_mode else num_examples,
+                    num_examples=healthbench_num_examples,
                     n_repeats=1,
                     n_threads=args.n_threads or 1,
                     subset_name=None,
@@ -120,7 +127,7 @@ def main():
             case "healthbench_hard":
                 return HealthBenchEval(
                     grader_model=grading_sampler,
-                    num_examples=10 if debug_mode else num_examples,
+                    num_examples=healthbench_num_examples,
                     n_repeats=1,
                     n_threads=args.n_threads or 1,
                     subset_name="hard",
@@ -128,7 +135,7 @@ def main():
             case "healthbench_consensus":
                 return HealthBenchEval(
                     grader_model=grading_sampler,
-                    num_examples=10 if debug_mode else num_examples,
+                    num_examples=healthbench_num_examples,
                     n_repeats=1,
                     n_threads=args.n_threads or 1,
                     subset_name="consensus",

--- a/gpt_oss/evals/__main__.py
+++ b/gpt_oss/evals/__main__.py
@@ -3,23 +3,16 @@ import json
 from datetime import datetime
 
 from . import report
-from .basic_eval import BasicEval
-from .gpqa_eval import GPQAEval
 from .aime_eval import AIME25Eval
-from .healthbench_eval import HealthBenchEval
+from .basic_eval import BasicEval
 from .chat_completions_sampler import (
     OPENAI_SYSTEM_MESSAGE_API,
     ChatCompletionsSampler,
 )
+from .cli_utils import resolve_num_examples
+from .gpqa_eval import GPQAEval
+from .healthbench_eval import HealthBenchEval
 from .responses_sampler import ResponsesSampler
-
-
-def _resolve_num_examples(
-    explicit_examples: int | None, debug_mode: bool, debug_default: int
-) -> int | None:
-    if explicit_examples is not None:
-        return explicit_examples
-    return debug_default if debug_mode else None
 
 
 def main():
@@ -103,8 +96,8 @@ def main():
     )
 
     def get_evals(eval_name, debug_mode):
-        num_examples = _resolve_num_examples(args.examples, debug_mode, 5)
-        healthbench_num_examples = _resolve_num_examples(args.examples, debug_mode, 10)
+        num_examples = resolve_num_examples(args.examples, debug_mode, 5)
+        healthbench_num_examples = resolve_num_examples(args.examples, debug_mode, 10)
         # Set num_examples = None to reproduce full evals
         match eval_name:
             case "basic":

--- a/gpt_oss/evals/__main__.py
+++ b/gpt_oss/evals/__main__.py
@@ -9,7 +9,7 @@ from .chat_completions_sampler import (
     OPENAI_SYSTEM_MESSAGE_API,
     ChatCompletionsSampler,
 )
-from .cli_utils import resolve_n_repeats, resolve_num_examples
+from .cli_utils import resolve_gpqa_debug_mode, resolve_n_repeats, resolve_num_examples
 from .gpqa_eval import GPQAEval
 from .healthbench_eval import HealthBenchEval
 from .responses_sampler import ResponsesSampler
@@ -107,7 +107,7 @@ def main():
                 return GPQAEval(
                     n_repeats=n_repeats,
                     num_examples=num_examples,
-                    debug=debug_mode,
+                    debug=resolve_gpqa_debug_mode(args.examples, debug_mode),
                     n_threads=args.n_threads or 1,
                 )
             case "healthbench":

--- a/gpt_oss/evals/__main__.py
+++ b/gpt_oss/evals/__main__.py
@@ -9,7 +9,7 @@ from .chat_completions_sampler import (
     OPENAI_SYSTEM_MESSAGE_API,
     ChatCompletionsSampler,
 )
-from .cli_utils import resolve_num_examples
+from .cli_utils import resolve_n_repeats, resolve_num_examples
 from .gpqa_eval import GPQAEval
 from .healthbench_eval import HealthBenchEval
 from .responses_sampler import ResponsesSampler
@@ -98,13 +98,14 @@ def main():
     def get_evals(eval_name, debug_mode):
         num_examples = resolve_num_examples(args.examples, debug_mode, 5)
         healthbench_num_examples = resolve_num_examples(args.examples, debug_mode, 10)
+        n_repeats = resolve_n_repeats(args.examples, debug_mode)
         # Set num_examples = None to reproduce full evals
         match eval_name:
             case "basic":
                 return BasicEval()
             case "gpqa":
                 return GPQAEval(
-                    n_repeats=1 if args.debug else 8,
+                    n_repeats=n_repeats,
                     num_examples=num_examples,
                     debug=debug_mode,
                     n_threads=args.n_threads or 1,
@@ -135,7 +136,7 @@ def main():
                 )
             case "aime25":
                 return AIME25Eval(
-                    n_repeats=1 if args.debug else 8,
+                    n_repeats=n_repeats,
                     num_examples=num_examples,
                     n_threads=args.n_threads or 1,
                 )

--- a/gpt_oss/evals/cli_utils.py
+++ b/gpt_oss/evals/cli_utils.py
@@ -1,0 +1,6 @@
+def resolve_num_examples(
+    explicit_examples: int | None, debug_mode: bool, debug_default: int
+) -> int | None:
+    if explicit_examples is not None:
+        return explicit_examples
+    return debug_default if debug_mode else None

--- a/gpt_oss/evals/cli_utils.py
+++ b/gpt_oss/evals/cli_utils.py
@@ -8,3 +8,7 @@ def resolve_num_examples(
 
 def resolve_n_repeats(explicit_examples: int | None, debug_mode: bool) -> int:
     return 1 if explicit_examples is not None or debug_mode else 8
+
+
+def resolve_gpqa_debug_mode(explicit_examples: int | None, debug_mode: bool) -> bool:
+    return debug_mode and explicit_examples is None

--- a/gpt_oss/evals/cli_utils.py
+++ b/gpt_oss/evals/cli_utils.py
@@ -7,7 +7,8 @@ def resolve_num_examples(
 
 
 def resolve_n_repeats(explicit_examples: int | None, debug_mode: bool) -> int:
-    return 1 if explicit_examples is not None or debug_mode else 8
+    explicit_subset = explicit_examples is not None and explicit_examples != 0
+    return 1 if explicit_subset or debug_mode else 8
 
 
 def resolve_gpqa_debug_mode(explicit_examples: int | None, debug_mode: bool) -> bool:

--- a/gpt_oss/evals/cli_utils.py
+++ b/gpt_oss/evals/cli_utils.py
@@ -4,3 +4,7 @@ def resolve_num_examples(
     if explicit_examples is not None:
         return explicit_examples
     return debug_default if debug_mode else None
+
+
+def resolve_n_repeats(explicit_examples: int | None, debug_mode: bool) -> int:
+    return 1 if explicit_examples is not None or debug_mode else 8

--- a/gpt_oss/evals/cli_utils.py
+++ b/gpt_oss/evals/cli_utils.py
@@ -2,6 +2,8 @@ def resolve_num_examples(
     explicit_examples: int | None, debug_mode: bool, debug_default: int
 ) -> int | None:
     if explicit_examples is not None:
+        if explicit_examples == 0:
+            return debug_default if debug_mode else None
         return explicit_examples
     return debug_default if debug_mode else None
 

--- a/tests/gpt_oss/evals/test_cli_examples.py
+++ b/tests/gpt_oss/evals/test_cli_examples.py
@@ -1,0 +1,13 @@
+from gpt_oss.evals.__main__ import _resolve_num_examples
+
+
+def test_explicit_examples_override_debug_default() -> None:
+    assert _resolve_num_examples(2, debug_mode=True, debug_default=10) == 2
+
+
+def test_debug_default_is_used_without_explicit_examples() -> None:
+    assert _resolve_num_examples(None, debug_mode=True, debug_default=10) == 10
+
+
+def test_full_eval_keeps_unlimited_examples() -> None:
+    assert _resolve_num_examples(None, debug_mode=False, debug_default=10) is None

--- a/tests/gpt_oss/evals/test_cli_examples.py
+++ b/tests/gpt_oss/evals/test_cli_examples.py
@@ -1,4 +1,8 @@
-from gpt_oss.evals.cli_utils import resolve_n_repeats, resolve_num_examples
+from gpt_oss.evals.cli_utils import (
+    resolve_gpqa_debug_mode,
+    resolve_n_repeats,
+    resolve_num_examples,
+)
 
 
 def test_explicit_examples_override_debug_default() -> None:
@@ -23,3 +27,9 @@ def test_debug_run_uses_single_repeat() -> None:
 
 def test_full_run_keeps_eight_repeats() -> None:
     assert resolve_n_repeats(None, debug_mode=False) == 8
+
+
+def test_gpqa_fixed_debug_example_is_default_only() -> None:
+    assert resolve_gpqa_debug_mode(None, debug_mode=True) is True
+    assert resolve_gpqa_debug_mode(2, debug_mode=True) is False
+    assert resolve_gpqa_debug_mode(None, debug_mode=False) is False

--- a/tests/gpt_oss/evals/test_cli_examples.py
+++ b/tests/gpt_oss/evals/test_cli_examples.py
@@ -29,6 +29,10 @@ def test_full_run_keeps_eight_repeats() -> None:
     assert resolve_n_repeats(None, debug_mode=False) == 8
 
 
+def test_zero_examples_keeps_full_run_repeats() -> None:
+    assert resolve_n_repeats(0, debug_mode=False) == 8
+
+
 def test_gpqa_fixed_debug_example_is_default_only() -> None:
     assert resolve_gpqa_debug_mode(None, debug_mode=True) is True
     assert resolve_gpqa_debug_mode(2, debug_mode=True) is False

--- a/tests/gpt_oss/evals/test_cli_examples.py
+++ b/tests/gpt_oss/evals/test_cli_examples.py
@@ -1,4 +1,4 @@
-from gpt_oss.evals.cli_utils import resolve_num_examples
+from gpt_oss.evals.cli_utils import resolve_n_repeats, resolve_num_examples
 
 
 def test_explicit_examples_override_debug_default() -> None:
@@ -11,3 +11,15 @@ def test_debug_default_is_used_without_explicit_examples() -> None:
 
 def test_full_eval_keeps_unlimited_examples() -> None:
     assert resolve_num_examples(None, debug_mode=False, debug_default=10) is None
+
+
+def test_explicit_subset_uses_single_repeat() -> None:
+    assert resolve_n_repeats(2, debug_mode=False) == 1
+
+
+def test_debug_run_uses_single_repeat() -> None:
+    assert resolve_n_repeats(None, debug_mode=True) == 1
+
+
+def test_full_run_keeps_eight_repeats() -> None:
+    assert resolve_n_repeats(None, debug_mode=False) == 8

--- a/tests/gpt_oss/evals/test_cli_examples.py
+++ b/tests/gpt_oss/evals/test_cli_examples.py
@@ -1,13 +1,13 @@
-from gpt_oss.evals.__main__ import _resolve_num_examples
+from gpt_oss.evals.cli_utils import resolve_num_examples
 
 
 def test_explicit_examples_override_debug_default() -> None:
-    assert _resolve_num_examples(2, debug_mode=True, debug_default=10) == 2
+    assert resolve_num_examples(2, debug_mode=True, debug_default=10) == 2
 
 
 def test_debug_default_is_used_without_explicit_examples() -> None:
-    assert _resolve_num_examples(None, debug_mode=True, debug_default=10) == 10
+    assert resolve_num_examples(None, debug_mode=True, debug_default=10) == 10
 
 
 def test_full_eval_keeps_unlimited_examples() -> None:
-    assert _resolve_num_examples(None, debug_mode=False, debug_default=10) is None
+    assert resolve_num_examples(None, debug_mode=False, debug_default=10) is None

--- a/tests/gpt_oss/evals/test_cli_examples.py
+++ b/tests/gpt_oss/evals/test_cli_examples.py
@@ -17,6 +17,14 @@ def test_full_eval_keeps_unlimited_examples() -> None:
     assert resolve_num_examples(None, debug_mode=False, debug_default=10) is None
 
 
+def test_zero_examples_keeps_full_run_outside_debug() -> None:
+    assert resolve_num_examples(0, debug_mode=False, debug_default=10) is None
+
+
+def test_zero_examples_uses_debug_default_in_debug_mode() -> None:
+    assert resolve_num_examples(0, debug_mode=True, debug_default=10) == 10
+
+
 def test_explicit_subset_uses_single_repeat() -> None:
     assert resolve_n_repeats(2, debug_mode=False) == 1
 


### PR DESCRIPTION
## Summary

Make the eval CLI's documented `--examples` override apply consistently to sample counts, GPQA debug selection, and repeat counts.

Three CLI paths were inconsistent:

- HealthBench debug runs hard-coded 10 examples even when the user supplied another positive count;
- non-debug AIME and GPQA kept `n_repeats=8` when an explicit subset was requested, which violates those constructors' `n_repeats == 1` subset requirement;
- GPQA debug mode always selected one fixed Espresso example and ignored an explicit positive sample count.

Fixes #292.
Fixes #298.
Fixes #299.

## Fix

- a positive explicit sample count wins over the eval-specific debug default;
- `--examples 0` means full/unlimited evaluation outside debug mode and uses the eval-specific debug default in debug mode;
- HealthBench therefore retains its debug default of 10 when no count or zero is supplied;
- positive explicit AIME/GPQA subsets use one repeat;
- non-debug `--examples 0` retains eight repeats;
- debug AIME/GPQA runs use one repeat;
- the fixed GPQA debug example is used only when no explicit sample count is supplied;
- full non-debug AIME/GPQA evaluations retain eight repeats;
- keep dependency-free resolution helpers in lightweight `cli_utils.py`.

## Regression coverage

Adds lightweight tests for explicit, debug-default, full-run, and zero-example sample/repeat selection, plus GPQA fixed-debug versus explicit-subset selection.

Datasets, scoring, sampler configuration, and full-eval defaults are otherwise unchanged.