### PR TITLE
Handle zero-example eval subsets and empty progress mapping

### DIFF
--- a/gpt_oss/evals/aime_eval.py
+++ b/gpt_oss/evals/aime_eval.py
@@ -3,9 +3,10 @@ AIME 2025: https://huggingface.co/datasets/opencompass/AIME2025
 """
 import random
 import re
-import pandas
-from . import report
 
+import pandas
+
+from . import report
 from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
 
 
@@ -14,28 +15,32 @@ AIME_TEMPLATE = """
 Please reason step by step, and put your final answer within \\boxed{{}}.
 """
 
+
 def format_aime_question(row):
     return AIME_TEMPLATE.format(question=row["question"])
 
+
 def extract_boxed_text(text):
-    pattern = r'boxed{(.*?)}|framebox{(.*?)}'
+    pattern = r"boxed{(.*?)}|framebox{(.*?)}"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
         for match in matches[::-1]:
             for group in match:
                 if group != "":
-                    return group.split(',')[-1].strip()
-    pattern = r'\d+'  # get the last integer if no pattern found
+                    return group.split(",")[-1].strip()
+    pattern = r"\d+"  # get the last integer if no pattern found
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
         return matches[-1]
     return ""
+
 
 def normalize_number(s):
     match = re.match(r"\d+", s)  # match digits from the start
     if not match:
         return None
     return match.group(0)
+
 
 class AIME25Eval(Eval):
     def __init__(
@@ -44,19 +49,31 @@ class AIME25Eval(Eval):
         num_examples: int | None = None,  # restrict to a subset of the data for debugging
         n_threads: int = 1,
     ):
-        path1 = f"https://huggingface.co/datasets/opencompass/AIME2025/raw/main/aime2025-I.jsonl"
+        path1 = "https://huggingface.co/datasets/opencompass/AIME2025/raw/main/aime2025-I.jsonl"
         df1 = pandas.read_json(path1, lines=True)
-        path2 = f"https://huggingface.co/datasets/opencompass/AIME2025/raw/main/aime2025-II.jsonl"
+        path2 = "https://huggingface.co/datasets/opencompass/AIME2025/raw/main/aime2025-II.jsonl"
         df2 = pandas.read_json(path2, lines=True)
-        examples = [row.to_dict() for _, row in df1.iterrows()] + [row.to_dict() for _, row in df2.iterrows()]
-        examples = [{
-            "question": row["question"],
-            "answer": normalize_number(row["answer"]) if isinstance(row["answer"], str) else row["answer"],
-        } for row in examples]
+        examples = [row.to_dict() for _, row in df1.iterrows()] + [
+            row.to_dict() for _, row in df2.iterrows()
+        ]
+        examples = [
+            {
+                "question": row["question"],
+                "answer": normalize_number(row["answer"])
+                if isinstance(row["answer"], str)
+                else row["answer"],
+            }
+            for row in examples
+        ]
         rng = random.Random(0)
-        if num_examples:
-            assert n_repeats == 1, "n_repeats only supported for num_examples = None"
-            examples = rng.sample(examples, num_examples)
+        if num_examples is not None:
+            if num_examples < 0:
+                raise ValueError("num_examples must be non-negative")
+            if num_examples == 0:
+                examples = []
+            else:
+                assert n_repeats == 1, "n_repeats only supported for num_examples = None"
+                examples = rng.sample(examples, num_examples)
         examples = examples * n_repeats
         examples = [example | {"permutation": rng.sample(range(4), 4)} for example in examples]
         self.examples = examples
@@ -66,16 +83,14 @@ class AIME25Eval(Eval):
     def __call__(self, sampler: SamplerBase) -> EvalResult:
         def fn(row: dict):
             prompt_messages = [
-                sampler._pack_message(
-                    content=format_aime_question(row), role="user"
-                )
+                sampler._pack_message(content=format_aime_question(row), role="user")
             ]
             sampler_response = sampler(prompt_messages)
             response_text = sampler_response.response_text
             actual_queried_prompt_messages = sampler_response.actual_queried_message_list
             extracted_answer = extract_boxed_text(response_text)
             correct_answer = int(row["answer"])
-            try: # All AIME answers are integers, so we convert the extracted answer to an integer
+            try:  # All AIME answers are integers, so we convert the extracted answer to an integer
                 extracted_answer = int(extracted_answer)
             except (ValueError, TypeError):
                 extracted_answer = None
@@ -94,4 +109,3 @@ class AIME25Eval(Eval):
 
         results = report.map_with_progress(fn, self.examples, num_threads=self.n_threads)
         return report.aggregate_results(results)
-

--- a/gpt_oss/evals/gpqa_eval.py
+++ b/gpt_oss/evals/gpqa_eval.py
@@ -9,8 +9,8 @@ import random
 import pandas
 
 from . import report
-from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
 from .abcd_grader import extract_abcd
+from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
 
 
 QUERY_TEMPLATE_MULTICHOICE = """
@@ -44,12 +44,21 @@ class GPQAEval(Eval):
         rng = random.Random(0)
 
         if debug:
-            examples = [row.to_dict() for _, row in df.iterrows() if "ESPRESSO spectrograph, please" in row["Question"]]
+            examples = [
+                row.to_dict()
+                for _, row in df.iterrows()
+                if "ESPRESSO spectrograph, please" in row["Question"]
+            ]
         else:
             examples = [row.to_dict() for _, row in df.iterrows()]
-            if num_examples:
-                assert n_repeats == 1, "n_repeats only supported for num_examples = None"
-                examples = rng.sample(examples, num_examples)
+            if num_examples is not None:
+                if num_examples < 0:
+                    raise ValueError("num_examples must be non-negative")
+                if num_examples == 0:
+                    examples = []
+                else:
+                    assert n_repeats == 1, "n_repeats only supported for num_examples = None"
+                    examples = rng.sample(examples, num_examples)
 
         examples = examples * n_repeats
         examples = [example | {"permutation": rng.sample(range(4), 4)} for example in examples]
@@ -69,12 +78,14 @@ class GPQAEval(Eval):
             correct_index = choices.index(row["Correct Answer"])
             correct_answer = "ABCD"[correct_index]
             choices_dict = dict(
-                A=choices[0], B=choices[1], C=choices[2], D=choices[3], Question=row["Question"]
+                A=choices[0],
+                B=choices[1],
+                C=choices[2],
+                D=choices[3],
+                Question=row["Question"],
             )
             prompt_messages = [
-                sampler._pack_message(
-                    content=format_multichoice_question(choices_dict), role="user"
-                )
+                sampler._pack_message(content=format_multichoice_question(choices_dict), role="user")
             ]
             sampler_response = sampler(prompt_messages)
             response_text = sampler_response.response_text

--- a/gpt_oss/evals/report.py
+++ b/gpt_oss/evals/report.py
@@ -88,6 +88,9 @@ def map_with_progress(
     """
     Apply f to each element of xs, using a ThreadPool, and show progress.
     """
+    if not xs:
+        return []
+
     pbar_fn = tqdm if pbar else lambda x, *args, **kwargs: x
 
     if os.getenv("debug"):

--- a/tests/gpt_oss/evals/test_report.py
+++ b/tests/gpt_oss/evals/test_report.py
@@ -1,0 +1,17 @@
+from gpt_oss.evals.report import map_with_progress
+
+
+def test_empty_input_returns_without_calling_mapper() -> None:
+    called = False
+
+    def fail_if_called(_):
+        nonlocal called
+        called = True
+        raise AssertionError("mapper must not run for an empty sample set")
+
+    assert map_with_progress(fail_if_called, [], pbar=True) == []
+    assert called is False
+
+
+def test_empty_input_without_progress_returns_empty() -> None:
+    assert map_with_progress(lambda value: value, [], pbar=False) == []

--- a/tests/gpt_oss/evals/test_zero_examples.py
+++ b/tests/gpt_oss/evals/test_zero_examples.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import pytest
+
+from gpt_oss.evals import aime_eval, gpqa_eval
+
+
+def test_aime_zero_examples_produces_empty_subset(monkeypatch) -> None:
+    frame = pd.DataFrame([{"question": "q", "answer": "1"}])
+    monkeypatch.setattr(aime_eval.pandas, "read_json", lambda *args, **kwargs: frame)
+
+    evaluation = aime_eval.AIME25Eval(num_examples=0)
+
+    assert evaluation.examples == []
+
+
+def test_aime_rejects_negative_example_count(monkeypatch) -> None:
+    frame = pd.DataFrame([{"question": "q", "answer": "1"}])
+    monkeypatch.setattr(aime_eval.pandas, "read_json", lambda *args, **kwargs: frame)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        aime_eval.AIME25Eval(num_examples=-1)
+
+
+def test_gpqa_zero_examples_produces_empty_subset(monkeypatch) -> None:
+    frame = pd.DataFrame(
+        [
+            {
+                "Question": "q",
+                "Correct Answer": "a",
+                "Incorrect Answer 1": "b",
+                "Incorrect Answer 2": "c",
+                "Incorrect Answer 3": "d",
+            }
+        ]
+    )
+    monkeypatch.setattr(gpqa_eval.pandas, "read_csv", lambda *args, **kwargs: frame)
+
+    evaluation = gpqa_eval.GPQAEval(num_examples=0)
+
+    assert evaluation.examples == []
+
+
+def test_gpqa_rejects_negative_example_count(monkeypatch) -> None:
+    frame = pd.DataFrame(
+        [
+            {
+                "Question": "q",
+                "Correct Answer": "a",
+                "Incorrect Answer 1": "b",
+                "Incorrect Answer 2": "c",
+                "Incorrect Answer 3": "d",
+            }
+        ]
+    )
+    monkeypatch.setattr(gpqa_eval.pandas, "read_csv", lambda *args, **kwargs: frame)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        gpqa_eval.GPQAEval(num_examples=-1)


### PR DESCRIPTION
## Summary

Make `num_examples=0` mean an empty AIME/GPQA evaluation and ensure empty eval inputs execute without constructing a zero-worker thread pool.

Two paths had to be fixed together:

- AIME and non-debug GPQA treated zero as falsey and silently evaluated the full dataset;
- once zero is represented correctly, `map_with_progress([])` attempted `ThreadPool(0)` and failed before an empty result could be returned.

Fixes #288.
Fixes #294.

## Fix

- distinguish `None` from an explicit zero sample count;
- return an empty example list for `num_examples=0`;
- reject negative sample counts with a clear `ValueError`;
- return `[]` from `map_with_progress()` before creating workers when the input is empty;
- preserve existing positive subset sampling and full-dataset behavior.

## Regression coverage

Adds deterministic, network-free tests for:

- zero and negative AIME sample counts;
- zero and negative GPQA sample counts;
- empty progress-map inputs with progress enabled/disabled;
- ensuring the mapper is never called for an empty list.

Question formatting, grading, positive subset selection, and non-empty threaded execution are unchanged.