### PR TITLE
Restore html2text globals safely after browser conversion

### DIFF
--- a/gpt_oss/tools/simple_browser/page_contents.py
+++ b/gpt_oss/tools/simple_browser/page_contents.py
@@ -8,6 +8,7 @@ import dataclasses
 import functools
 import logging
 import re
+import threading
 from urllib.parse import urljoin, urlparse
 
 import aiohttp
@@ -28,6 +29,7 @@ HTML_TAGS_SEQ_RE = re.compile(r"(?<=\w)((<[^>]*>)+)(?=\w)")
 WHITESPACE_ANCHOR_RE = re.compile(r"(【\@[^】]+】)(\s+)")
 EMPTY_LINE_RE = re.compile(r"^\s+$", flags=re.MULTILINE)
 EXTRA_NEWLINE_RE = re.compile(r"\n(\s*\n)+")
+_HTML2TEXT_ESCAPE_LOCK = threading.Lock()
 
 
 class Extract(pydantic.BaseModel):  # A search result snippet or a quotable extract
@@ -170,7 +172,7 @@ def _get_text(node: lxml.html.HtmlElement) -> str:
 
 
 def _remove_node(node: lxml.html.HtmlElement) -> None:
-    """Removes a node from its parent in the lxml tree."""
+    """Removes a node from its parent."""
     node.getparent().remove(node)
 
 
@@ -188,22 +190,25 @@ def html_to_text(html: str) -> str:
     html = re.sub(HTML_SUB_RE, r"_{\2}", html)
     # add spaces between tags such as table cells
     html = re.sub(HTML_TAGS_SEQ_RE, r" \1", html)
-    # we don't need to escape markdown, so monkey-patch the logic
-    orig_escape_md = html2text.utils.escape_md
-    orig_escape_md_section = html2text.utils.escape_md_section
-    html2text.utils.escape_md = _escape_md
-    html2text.utils.escape_md_section = _escape_md_section
-    h = html2text.HTML2Text()
-    h.ignore_links = True
-    h.ignore_images = True
-    h.body_width = 0  # no wrapping
-    h.ignore_tables = True
-    h.unicode_snob = True
-    h.ignore_emphasis = True
-    result = h.handle(html).strip()
-    html2text.utils.escape_md = orig_escape_md
-    html2text.utils.escape_md_section = orig_escape_md_section
-    return result
+    # html2text uses module-level escape helpers. Serialize the temporary
+    # override and always restore the originals, including when handle() fails.
+    with _HTML2TEXT_ESCAPE_LOCK:
+        orig_escape_md = html2text.utils.escape_md
+        orig_escape_md_section = html2text.utils.escape_md_section
+        html2text.utils.escape_md = _escape_md
+        html2text.utils.escape_md_section = _escape_md_section
+        try:
+            h = html2text.HTML2Text()
+            h.ignore_links = True
+            h.ignore_images = True
+            h.body_width = 0  # no wrapping
+            h.ignore_tables = True
+            h.unicode_snob = True
+            h.ignore_emphasis = True
+            return h.handle(html).strip()
+        finally:
+            html2text.utils.escape_md = orig_escape_md
+            html2text.utils.escape_md_section = orig_escape_md_section
 
 
 def _remove_math(root: lxml.html.HtmlElement) -> None:

--- a/tests/gpt_oss/tools/simple_browser/test_page_contents.py
+++ b/tests/gpt_oss/tools/simple_browser/test_page_contents.py
@@ -1,0 +1,19 @@
+import pytest
+
+from gpt_oss.tools.simple_browser import page_contents
+
+
+def test_html_to_text_restores_escape_helpers_after_failure(monkeypatch) -> None:
+    original_escape_md = page_contents.html2text.utils.escape_md
+    original_escape_md_section = page_contents.html2text.utils.escape_md_section
+
+    def fail_handle(self, html):
+        raise RuntimeError("conversion failed")
+
+    monkeypatch.setattr(page_contents.html2text.HTML2Text, "handle", fail_handle)
+
+    with pytest.raises(RuntimeError, match="conversion failed"):
+        page_contents.html_to_text("<p>test</p>")
+
+    assert page_contents.html2text.utils.escape_md is original_escape_md
+    assert page_contents.html2text.utils.escape_md_section is original_escape_md_section


### PR DESCRIPTION
## Summary

Make simple-browser HTML conversion restore its temporary `html2text` monkey patches even when conversion fails, and serialize the process-wide override across threads.

`html_to_text()` temporarily replaces `html2text.utils.escape_md` and `escape_md_section`. The current restoration runs only after `HTML2Text.handle()` succeeds, so an exception leaves the replacement functions installed process-wide. Concurrent conversions can also race over the same globals.

Fixes #296.

## Fix

- guard the temporary global override with a module-level lock;
- restore both original html2text functions in `finally`;
- return the converted text directly from the protected block.

## Regression coverage

Adds a focused test that forces `HTML2Text.handle()` to raise and verifies both html2text helpers are restored to their exact original objects afterward.

HTML normalization options and successful conversion output are unchanged.